### PR TITLE
Add support for passing resource kind to `KubectlClient::Rollout` module helpers

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -282,7 +282,7 @@ module KubectlClient
       resource_name : String,
       container_name : String,
       image_name : String,
-      version_tag String | Nil = nil,
+      version_tag : String | Nil = nil,
       namespace : String | Nil = nil
     ) : Bool
       # use --record when setting image to have history

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -286,14 +286,21 @@ module KubectlClient
   end
 
   module Set
-    def self.image(deployment_name, container_name, image_name, version_tag=nil, namespace : String | Nil = nil) : Bool
+    def self.image(
+      resource_kind : String,
+      resource_name : String,
+      container_name : String,
+      image_name : String,
+      version_tag String | Nil = nil,
+      namespace : String | Nil = nil
+    ) : Bool
       # use --record when setting image to have history
       #TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
       cmd = ""
       if version_tag
-        cmd = "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name}:#{version_tag} --record"
+        cmd = "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name}:#{version_tag} --record"
       else
-        cmd = "kubectl set image deployment/#{deployment_name} #{container_name}=#{image_name} --record"
+        cmd = "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
       end
       if namespace
         cmd = "#{cmd} -n #{namespace}"

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -104,7 +104,7 @@ module KubectlClient
   end
 
   module Rollout
-    def self.status(kind : String, resource_name: String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+    def self.status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       if namespace
         cmd = "#{cmd} -n #{namespace}"

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -114,8 +114,8 @@ module KubectlClient
       result[:status].success?
     end
 
-    def self.undo(deployment_name, namespace : String | Nil = nil) : Bool
-      cmd = "kubectl rollout undo deployment/#{deployment_name}"
+    def self.undo(kind : String, resource_name : String, namespace : String | Nil = nil) : Bool
+      cmd = "kubectl rollout undo #{kind}/#{resource_name}"
       if namespace
         cmd = "#{cmd} -n #{namespace}"
       end

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -109,7 +109,7 @@ module KubectlClient
       if namespace
         cmd = "#{cmd} -n #{namespace}"
       end
-      result = ShellCmd.run(cmd, "KubectlClient::Rollout.resource_status")
+      result = ShellCmd.run(cmd, "KubectlClient::Rollout.status")
       Log.debug { "rollout status: #{result[:status].success?}" }
       result[:status].success?
     end

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -113,7 +113,7 @@ module KubectlClient
       result[:status].success?
     end
 
-    def self.resource_status(kind, resource_name, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+    def self.resource_status(kind : String, resource_name: String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       if namespace
         cmd = "#{cmd} -n #{namespace}"

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -104,16 +104,7 @@ module KubectlClient
   end
 
   module Rollout
-    def self.status(deployment_name, namespace : String | Nil = nil, timeout="30s") : Bool
-      cmd = "kubectl rollout status deployment/#{deployment_name} --timeout=#{timeout}"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Rollout.status")
-      result[:status].success?
-    end
-
-    def self.resource_status(kind : String, resource_name: String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+    def self.status(kind : String, resource_name: String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       if namespace
         cmd = "#{cmd} -n #{namespace}"


### PR DESCRIPTION
## Issues:
Refs: cncf/cnf-testsuite#1726

## Description
Add support for passing resource kind to `KubectlClient::Rollout` module helpers.
This is to be able to use the Rollout commands with statefulsets too.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
