### PR TITLE
Add new `KubectlClient.exec_bg` helper

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -42,7 +42,7 @@ module KubectlClient
 
     def self.new(cmd, log_prefix, force_output=false)
       Log.info { "#{log_prefix} command: #{cmd}" }
-      status = Process.new(
+      process = Process.new(
         cmd,
         shell: true,
         output: output = IO::Memory.new,
@@ -58,7 +58,7 @@ module KubectlClient
       if stderr.to_s.size > 1
         Log.info { "#{log_prefix} stderr: #{stderr.to_s}" }
       end
-      {status: status, output: output.to_s, error: stderr.to_s}
+      {process: process, output: output.to_s, error: stderr.to_s}
     end
   end
 
@@ -346,7 +346,6 @@ module KubectlClient
 
     # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
     def self.image(
-      resource_kind : String,
       resource_name : String,
       container_name : String,
       image_name : String,

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -100,18 +100,25 @@ module KubectlClient
     ShellCmd.run(cmd, "KubectlClient.describe", force_output: force_output)
   end
 
-  def self.exec(command, namespace : String | Nil = nil, force_output : Bool = false, background=false)
+  def self.exec(command, namespace : String | Nil = nil, force_output : Bool = false)
+    full_cmd = construct_exec_cmd(command, namespace)
+    ShellCmd.run(full_cmd, "KubectlClient.exec", force_output)
+  end
+
+  def self.exec_bg(command, namespace : String | Nil = nil, force_output : Bool = false)
+    full_cmd = construct_exec_cmd(command, namespace)
+    ShellCmd.new(full_cmd, "KubectlClient.exec_bg", force_output)
+  end
+
+  # Returns a command as a string to be used in exec or exec_bg
+  def self.construct_exec_cmd(command, namespace : String | Nil = nil) : String
     full_cmd = ["kubectl", "exec"]
     if namespace
       full_cmd << "-n #{namespace}"
     end
     full_cmd << command
     full_cmd = full_cmd.join(" ")
-    if background
-      ShellCmd.new(full_cmd, "KubectlClient.exec", force_output)
-    else
-      ShellCmd.run(full_cmd, "KubectlClient.exec", force_output)
-    end
+    return full_cmd
   end
 
   def self.cp(command)

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -136,6 +136,18 @@ module KubectlClient
   end
 
   module Rollout
+    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
+    def self.status(resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+      Log.info { "Decrecated method. Pass kind in the args KubectlClient::Rollout.status(kind, resource_name, namespace, timeout)" }
+      status(kind: "deployment", resource_name: resource_name, namespace: namespace, timeout: timeout)
+    end
+
+    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
+    def self.undo(resource_name : String, namespace : String | Nil = nil) : Bool
+      Log.info { "Decrecated method. Pass kind in the args KubectlClient::Rollout.undo(kind, resource_name, namespace)" }
+      undo(kind: "deployment", resource_name: resource_name, namespace: namespace)
+    end
+
     def self.status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       if namespace

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -148,6 +148,11 @@ module KubectlClient
       undo(kind: "deployment", resource_name: resource_name, namespace: namespace)
     end
 
+    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
+    def self.resource_status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+      status(kind: kind, resource_name: resource_name, namespace: namespace, timeout: timeout)
+    end
+
     def self.status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       if namespace

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -352,7 +352,7 @@ module KubectlClient
     # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
     def self.image(
       resource_name : String,
-      container_name : String,
+      container_name : JSON::Any,
       image_name : String,
       version_tag : String | Nil = nil,
       namespace : String | Nil = nil
@@ -360,7 +360,7 @@ module KubectlClient
       return image(
         resource_kind: "deployment",
         resource_name: resource_name,
-        container_name: container_name,
+        container_name: container_name.as_s,
         image_name: image_name,
         version_tag: version_tag,
         namespace: namespace

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -343,6 +343,25 @@ module KubectlClient
       result = ShellCmd.run(cmd, "KubectlClient::Set.image")
       result[:status].success?
     end
+
+    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
+    def self.image(
+      resource_kind : String,
+      resource_name : String,
+      container_name : String,
+      image_name : String,
+      version_tag : String | Nil = nil,
+      namespace : String | Nil = nil
+    ) : Bool
+      return image(
+        resource_kind: "deployment",
+        resource_name: resource_name,
+        container_name: container_name,
+        image_name: image_name,
+        version_tag: version_tag,
+        namespace: namespace
+      )
+    end
   end
 
   #TODO move this out into its own file


### PR DESCRIPTION
## Issues:
Refs: cncf/cnf-testsuite#1738

## Description

#### These changes help with resolving compile issues mentioned in cncf/cnf-testsuite#1738
* Removes `background` arg from `KubectlClient.exec`. This caused errors due to unexpected return value when used in the testsuite.
* Adds new helper `KubectlClient.exec_bg` for executing in the background. This should help any ongoing work in other branches and behaves the same as the earlier `exec` helper with `background=true`.

#### Additional changes to help smooth transition for cncf/cnf-testsuite#1726
* Add deprecated helper functions with old signatures as per usage in main branch in `cncf/cnf-testsuite`.
* This ensures that the main branch of `kubectl_client` works with the cnf-testsuite when compiled.
* These changes have been tested with a fork of the main branch of `cncf/cnf-testsuite`
  * Branch name: `bug/1738`
  * Build link: https://github.com/cncf/cnf-testsuite/actions/runs/4174668958

#### More notes
For validation against the `main` branch of cnf-testsuite: This `exec-background` branch of `kubectl_client` is now being used by the `bug/1726` branch of `cncf/cnf-testsuite` and the build is green.

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [x] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
