### PR TITLE
get pods by the match selector labels if the resource is a deployment

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -1291,6 +1291,8 @@ module KubectlClient
       Log.debug { "resource_labels kind: #{kind} resource_name: #{resource_name}" }
       if kind.downcase == "service"
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "selector")
+      elsif kind.downcase == "deployment" 
+        resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "selector", "matchLabels")
       else
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "template", "metadata", "labels")
       end

--- a/spec/kubectl_client_spec.cr
+++ b/spec/kubectl_client_spec.cr
@@ -212,5 +212,18 @@ describe "KubectlClient" do
     KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
     KubectlClient::Delete.file("./spec/fixtures/dockerd_manifest.yml")
   end
+
+  it "'#KubectlClient.pods_by_resource' should return pods for a deployment ", tags: ["kubectl-status"]  do
+    cnf="./sample-cnfs/sample-coredns-cnf"
+    KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
+    KubectlClient::Get.resource_wait_for_install("Pod", "coredns")
+
+    resource = KubectlClient::Get.resource("Deployment", "coredns-coredns")
+    resp = KubectlClient::Get.pods_by_resource(resource)
+    Log.info { resp }
+    (resp && !resp.empty?).should be_true
+  ensure
+    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
+  end
 end
 


### PR DESCRIPTION
## Description
title says it all

## Issues:
Refs:  https://github.com/cncf/cnf-testsuite/issues/1706

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
