### PR TITLE
[feature/1822] Update kubectl version parsing to detect newer versions

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: kubectl_client
-version: 1.0.1
+version: 1.0.2
 
 authors:
   - William Harris <wharris@upscalews.com>

--- a/src/utils/system_information.cr
+++ b/src/utils/system_information.cr
@@ -107,26 +107,47 @@ end
 # version # => "1.12"
 # ```
 #
-# For reference, below are example client and server version strings from "kubectl version" output
-#
-# ```
-# Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.0", GitCommit:"cb303e613a121a29364f75cc67d3d580833a7479", GitTreeState:"clean", BuildDate:"2021-04-08T16:31:21Z", GoVersion:"go1.16.1", Compiler:"gc", Platform:"linux/amd64"}
-# Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
-# ```
-#
-# TODO Function could be updated to rely on the JSON output of "kubectl version -o json" instead of regex parsing
-#
 # Returns the version as a string (Example: 1.12, 1.20, etc)
 def kubectl_version(kubectl_response, version_for = "client", verbose = false)
-  # version_for can be "client" or "server"
-  resp = kubectl_response.match /#{version_for.capitalize} Version: version.Info{(Major:"(([0-9]{1,3})"\, )Minor:"([0-9]{1,3}[+]?)")/
-  Log.for("verbose").info { resp } if verbose
+  version_info_json = kubectl_response
 
-  if resp
-    "#{resp && resp.not_nil![3]}.#{resp && resp.not_nil![4]}"
-  else
-    ""
+  # Strip the server connection warning if it exists in the output.
+  if kubectl_response.includes?("The connection to the server")
+    version_info_lines = version_info_json.split("\n")
+    version_info_json = version_info_lines[0, version_info_lines.size - 1].join("\n")
   end
+
+  # Look for the appropriate key depending on client or server version lookup
+  version_key = "clientVersion"
+  if version_for == "server"
+    version_key = "serverVersion"
+  end
+
+  # Attempt to parse version output
+  # Or return blank string if json parse exception
+  begin
+    version_data = JSON.parse(version_info_json)
+  rescue ex : JSON::ParseException
+    return ""
+  end
+
+  # If the specific server/client version info does not exist,
+  # then return blank string
+  if version_data.as_h.has_key?(version_key)
+    version_info = version_data[version_key]
+  else
+    return ""
+  end
+
+  # If major and minor keys do not exist, then return blank string
+  if version_info.as_h.has_key?("major") && version_info.as_h.has_key?("minor")
+    major_version = version_info["major"].as_s
+    minor_version = version_info["minor"].as_s
+  else
+    return ""
+  end
+
+  "#{major_version}.#{minor_version}"
 end
 
 # Check if client version is not too many versions behind server version

--- a/src/utils/system_information.cr
+++ b/src/utils/system_information.cr
@@ -82,18 +82,14 @@ def kubectl_installation(verbose = false, offline_mode = false)
 end
 
 def kubectl_global_response(verbose = false)
-  status = Process.run("kubectl version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
+  status = Process.run("kubectl version -o json", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
   Log.for("verbose").info { kubectl_response } if verbose
-  puts "kubectl-global-response-debug: #{kubectl_response.to_s}"
   kubectl_response.to_s
 end
 
 def kubectl_local_response(verbose = false)
-  current_dir = FileUtils.pwd
-  Log.for("verbose").info { current_dir } if verbose
-  status = Process.run("#{local_kubectl_path} version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
+  status = Process.run("#{local_kubectl_path} version -o json", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
   Log.for("verbose").info { kubectl_response.to_s } if verbose
-  puts "kubectl-local-response-debug: #{kubectl_response.to_s}"
   kubectl_response.to_s
 end
 

--- a/src/utils/system_information.cr
+++ b/src/utils/system_information.cr
@@ -107,8 +107,21 @@ end
 def kubectl_version(kubectl_response, version_for = "client", verbose = false)
   version_info_json = kubectl_response
 
+  # The version skew or the server connection warnings are mutually exclusive.
+  # Only one of them may be present in the output.
+
   # Strip the server connection warning if it exists in the output.
+  # Server connection warning looks like below:
+  # The connection to the server localhost:8080 was refused - did you specify the right host or port?
   if kubectl_response.includes?("The connection to the server")
+    version_info_lines = version_info_json.split("\n")
+    version_info_json = version_info_lines[0, version_info_lines.size - 1].join("\n")
+  end
+
+  # Strip the version skew warning if it exists in the output.
+  # Version skew warning looks like below:
+  # WARNING: version difference between client (1.28) and server (1.25) exceeds the supported minor version skew of +/-1
+  if kubectl_response.includes?("WARNING: version difference between client")
     version_info_lines = version_info_json.split("\n")
     version_info_json = version_info_lines[0, version_info_lines.size - 1].join("\n")
   end

--- a/src/utils/system_information.cr
+++ b/src/utils/system_information.cr
@@ -84,6 +84,7 @@ end
 def kubectl_global_response(verbose = false)
   status = Process.run("kubectl version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
   Log.for("verbose").info { kubectl_response } if verbose
+  puts "kubectl-global-response-debug: #{kubectl_response.to_s}"
   kubectl_response.to_s
 end
 
@@ -92,6 +93,7 @@ def kubectl_local_response(verbose = false)
   Log.for("verbose").info { current_dir } if verbose
   status = Process.run("#{local_kubectl_path} version", shell: true, output: kubectl_response = IO::Memory.new, error: stderr = IO::Memory.new)
   Log.for("verbose").info { kubectl_response.to_s } if verbose
+  puts "kubectl-local-response-debug: #{kubectl_response.to_s}"
   kubectl_response.to_s
 end
 


### PR DESCRIPTION
## Issues: cncf/cnf-testsuite#1822

## Description

* Adds support for detecting newer kubectl versions by parsing the kubectl version command's json output.
* Bump shard version to `1.0.2`.

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
