### PR TITLE
Add service account to the list of workload resources

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -12,7 +12,8 @@ module KubectlClient
                         pod: "Pod",
                         replicaset: "ReplicaSet",
                         statefulset: "StatefulSet",
-                        daemonset: "DaemonSet"}
+                        daemonset: "DaemonSet",
+                        service_account: "ServiceAccount"}
 
   # https://www.capitalone.com/tech/cloud/container-runtime/
   # todo add podman


### PR DESCRIPTION
## Related issue: cnti-testcatalog/testsuite#2003

## Description
Service Accounts should be included in the list of resources for the CNF.

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
