### PR TITLE
Add resource types supporting matchLabels

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -1309,9 +1309,10 @@ module KubectlClient
 
     def self.resource_spec_labels(kind : String, resource_name : String, namespace : String | Nil = nil) : JSON::Any
       Log.debug { "resource_labels kind: #{kind} resource_name: #{resource_name}" }
-      if kind.downcase == "service"
+      case kind.downcase
+      when "service"
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "selector")
-      elsif kind.downcase == "deployment" 
+      when "deployment", "statefulset", "replicaset", "daemonset", "job"
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "selector", "matchLabels")
       else
         resp = resource(kind, resource_name, namespace: namespace).dig?("spec", "template", "metadata", "labels")


### PR DESCRIPTION
Add more resource types supporting filtering using matchLabels.
As per supported types for matchLabels: https://kubernetes.io/docs/concepts/workloads/controllers/

## Description
(name of issue/change)

## Issues:
Refs: cnti-testcatalog/testsuite#2062

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
