### PR TITLE
Decrease number of logs during cnf_install and cnf_uninstall

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   docker_client:
     git: https://github.com/cnf-testsuite/docker_client.git
-    version: 0.1.0+git.commit.32dacefbc3dfcf98c8126ff793c97a3038e9b122
+    version: 1.0.0
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/src/constants.cr
+++ b/src/constants.cr
@@ -1,4 +1,5 @@
 module KubectlClient
 	DEFAULT_LOCAL_BINARY_PATH = "tools/git/linux-amd64/docker"
 	BASE_CONFIG = "./config.yml"
+	RESOURCE_WAIT_LOG_INTERVAL = 10
 end


### PR DESCRIPTION
Small PR that addresses looped logs during cnf install.

- Commit updated shard.lock after running 'shards install'
- Add new constant for repeated logs interval