### PR TITLE
Refactor KubectlClient module with focus on logging

### DIFF
--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -1,14 +1,17 @@
 require "totem"
 require "colorize"
 require "docker_client"
-require "./src/modules/get.cr"
-require "./src/modules/modules.cr"
+require "./src/modules/*"
 require "./src/utils/utils.cr"
 require "./src/utils/system_information.cr"
 
 module KubectlClient
+  Log = ::Log.for("k8s-client")
+
   alias K8sManifest = JSON::Any
   alias K8sManifestList = Array(JSON::Any)
+  alias CMDResult = NamedTuple(status: Process::Status, stdout: String, stderr: String)
+  alias BackgroundCMDResult = NamedTuple(process: Process, stdout: String, stderr: String)
 
   WORKLOAD_RESOURCES = {deployment:      "Deployment",
                         service:         "Service",
@@ -18,9 +21,11 @@ module KubectlClient
                         daemonset:       "DaemonSet",
                         service_account: "ServiceAccount"}
 
-  module ShellCmd
-    def self.run(cmd, log_prefix, force_output = false)
-      Log.info { "#{log_prefix} command: #{cmd}" }
+  module ShellCMD
+    # logger should have method name (any other scopes, if necessary) that is calling attached using .for() method.
+    def self.run(cmd, logger : ::Log = Log, force_output = false) : CMDResult
+      logger = logger.for("cmd")
+      logger.debug { "command: #{cmd}" }
       status = Process.run(
         cmd,
         shell: true,
@@ -28,20 +33,22 @@ module KubectlClient
         error: stderr = IO::Memory.new
       )
       if force_output == false
-        Log.debug { "#{log_prefix} output: #{output.to_s}" }
+        logger.debug { "output: #{output.to_s}" }
       else
-        Log.info { "#{log_prefix} output: #{output.to_s}" }
+        logger.info { "output: #{output.to_s}" }
       end
 
       # Don't have to output log line if stderr is empty
       if stderr.to_s.size > 1
-        Log.info { "#{log_prefix} stderr: #{stderr.to_s}" }
+        logger.warn { "stderr: #{stderr.to_s}" }
       end
-      {status: status, output: output.to_s, error: stderr.to_s}
+
+      CMDResult.new(status: status, output: output.to_s, error: stderr.to_s)
     end
 
-    def self.new(cmd, log_prefix, force_output = false)
-      Log.info { "#{log_prefix} command: #{cmd}" }
+    def self.new(cmd, logger : ::Log = Log, force_output = false) : CMDResult
+      logger = logger.for("cmd-background")
+      logger.debug { "command: #{cmd}" }
       process = Process.new(
         cmd,
         shell: true,
@@ -49,29 +56,32 @@ module KubectlClient
         error: stderr = IO::Memory.new
       )
       if force_output == false
-        Log.debug { "#{log_prefix} output: #{output.to_s}" }
+        logger.debug { "output: #{output.to_s}" }
       else
-        Log.info { "#{log_prefix} output: #{output.to_s}" }
+        logger.info { "output: #{output.to_s}" }
       end
 
       # Don't have to output log line if stderr is empty
       if stderr.to_s.size > 1
-        Log.info { "#{log_prefix} stderr: #{stderr.to_s}" }
+        logger.warn { "stderr: #{stderr.to_s}" }
       end
-      {process: process, output: output.to_s, error: stderr.to_s}
+
+      BackgroundCMDResult.new(process: process, output: output.to_s, error: stderr.to_s)
     end
   end
 
-  def self.installation_found?(verbose = false, offline_mode = false)
+  def self.installation_found?(verbose = false, offline_mode = false) : Bool
     kubectl_installation(verbose = false, offline_mode = false).includes?("kubectl found")
   end
 
-  def self.server_version
-    Log.debug { "KubectlClient.server_version" }
-    result = ShellCmd.run("kubectl version --output json", "KubectlClient.server_version", true)
+  def self.server_version : String
+    logger = Log.for("server_version")
+
+    result = ShellCMD.run("kubectl version --output json", logger)
     version = JSON.parse(result[:output])["serverVersion"]["gitVersion"].as_s
     version = version.gsub("v", "")
-    Log.info { "KubectlClient.server_version: #{version}" }
+
+    logger.info { "K8s server version is: #{version}" }
     version
   end
 end

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -8,8 +8,6 @@ require "./src/utils/system_information.cr"
 module KubectlClient
   Log = ::Log.for("k8s-client")
 
-  alias K8sManifest = JSON::Any
-  alias K8sManifestList = Array(JSON::Any)
   alias CMDResult = NamedTuple(status: Process::Status, stdout: String, stderr: String)
   alias BackgroundCMDResult = NamedTuple(process: Process, stdout: String, stderr: String)
 
@@ -74,6 +72,14 @@ module KubectlClient
       # TODO: raise different kind of exceptions based on type of error (network issue, resource does not exits etc.)
       unless result[:status].success?
         raise K8sClientCMDException.new(result[:error])
+      end
+    end
+
+    def parse_get_result(result : CMDResult)
+      if result[:status].success? && !result[:output].empty?
+        return JSON.parse(response)
+      else
+        return EMPTY_JSON
       end
     end
 

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -76,19 +76,13 @@ module KubectlClient
           raise AlreadyExistsError.new(result[:error], result[:status].exit_code)
         when /#{NOT_FOUND_ERR_MATCH}/.match(result[:error])
           raise NotFoundError.new(result[:error], result[:status].exit_code)
+        when /#{NETWORK_ERR_MATCH}/i.match(result[:error])
+          raise NetworkError.new(result[:error], result[:status].exit_code)
         else
-          raise K8sClientCMDException.new(result[:error], result[:status].exit_code)
+          raise UnspecifiedError.new(result[:error], result[:status].exit_code)
         end
       end
       result
-    end
-    
-    def self.parse_get_result(result : CMDResult)
-      if result[:status].success? && !result[:output].empty?
-        JSON.parse(result[:output])
-      else
-        EMPTY_JSON
-      end
     end
 
     class K8sClientCMDException < Exception
@@ -103,6 +97,12 @@ module KubectlClient
     end
 
     class NotFoundError < K8sClientCMDException
+    end
+
+    class NetworkError < K8sClientCMDException
+    end
+
+    class UnspecifiedError < K8sClientCMDException
     end
   end
 

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -6,7 +6,7 @@ require "./src/utils/utils.cr"
 require "./src/utils/system_information.cr"
 
 module KubectlClient
-  Log = ::Log.for("k8s-client")
+  Log = ::Log.for("KubectlClient")
 
   alias CMDResult = NamedTuple(status: Process::Status, output: String, error: String)
   alias BackgroundCMDResult = NamedTuple(process: Process, output: String, error: String)
@@ -44,7 +44,7 @@ module KubectlClient
       {status: status, output: output.to_s, error: stderr.to_s}
     end
 
-    def self.new(cmd, logger : ::Log = Log, force_output = false) : CMDResult
+    def self.new(cmd, logger : ::Log = Log, force_output = false) : BackgroundCMDResult
       logger = logger.for("cmd-background")
       logger.debug { "command: #{cmd}" }
       process = Process.new(

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -72,9 +72,9 @@ module KubectlClient
       unless result[:status].success?
         # Add new cases to this switch if needed
         case
-        when /#{result[:error]}/.match(ALREADY_EXISTS_ERR_MATCH)
+        when /#{ALREADY_EXISTS_ERR_MATCH}/.match(result[:error])
           raise AlreadyExistsError.new(result[:error], result[:status].exit_code)
-        when /#{result[:error]}/.match(NOT_FOUND_ERR_MATCH)
+        when /#{NOT_FOUND_ERR_MATCH}/.match(result[:error])
           raise NotFoundError.new(result[:error], result[:status].exit_code)
         else
           raise K8sClientCMDException.new(result[:error], result[:status].exit_code)

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -30,8 +30,8 @@ module KubectlClient
         output: output = IO::Memory.new,
         error: stderr = IO::Memory.new
       )
-      if force_output == false
-        logger.debug { "output: #{output}" }
+      if !force_output
+        logger.trace { "output: #{output}" }
       else
         logger.info { "output: #{output}" }
       end
@@ -53,8 +53,8 @@ module KubectlClient
         output: output = IO::Memory.new,
         error: stderr = IO::Memory.new
       )
-      if force_output == false
-        logger.debug { "output: #{output}" }
+      if !force_output
+        logger.trace { "output: #{output}" }
       else
         logger.info { "output: #{output}" }
       end

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -21,20 +21,16 @@ module KubectlClient
 
   module ShellCMD
     # logger should have method name (any other scopes, if necessary) that is calling attached using .for() method.
-    def self.run(cmd, logger : ::Log = Log, force_output = false) : CMDResult
+    def self.run(cmd, logger : ::Log = Log) : CMDResult
       logger = logger.for("cmd")
-      logger.debug { "command: #{cmd}" }
+      logger.trace { "command: #{cmd}" }
       status = Process.run(
         cmd,
         shell: true,
         output: output = IO::Memory.new,
         error: stderr = IO::Memory.new
       )
-      if !force_output
-        logger.trace { "output: #{output}" }
-      else
-        logger.info { "output: #{output}" }
-      end
+      logger.trace { "output: #{output}" }
 
       # Don't have to output log line if stderr is empty
       if stderr.to_s.size > 1
@@ -44,20 +40,16 @@ module KubectlClient
       {status: status, output: output.to_s, error: stderr.to_s}
     end
 
-    def self.new(cmd, logger : ::Log = Log, force_output = false) : BackgroundCMDResult
+    def self.new(cmd, logger : ::Log = Log) : BackgroundCMDResult
       logger = logger.for("cmd-background")
-      logger.debug { "command: #{cmd}" }
+      logger.trace { "command: #{cmd}" }
       process = Process.new(
         cmd,
         shell: true,
         output: output = IO::Memory.new,
         error: stderr = IO::Memory.new
       )
-      if !force_output
-        logger.trace { "output: #{output}" }
-      else
-        logger.info { "output: #{output}" }
-      end
+      logger.trace { "output: #{output}" }
 
       # Don't have to output log line if stderr is empty
       if stderr.to_s.size > 1
@@ -119,5 +111,9 @@ module KubectlClient
 
     logger.info { "K8s server version is: #{version}" }
     version
+  end
+
+  def self.names_from_json_array_to_s(resource : Array(JSON::Any)) : String
+    resource.map { |item| item.dig?("metadata", "name") }.join(", ")
   end
 end

--- a/kubectl_client.cr
+++ b/kubectl_client.cr
@@ -68,6 +68,17 @@ module KubectlClient
 
       BackgroundCMDResult.new(process: process, output: output.to_s, error: stderr.to_s)
     end
+
+    def raise_exc_on_error(&)
+      result = yield
+      # TODO: raise different kind of exceptions based on type of error (network issue, resource does not exits etc.)
+      unless result[:status].success?
+        raise K8sClientCMDException.new(result[:error])
+      end
+    end
+
+    class K8sClientCMDException < Exception
+    end
   end
 
   def self.installation_found?(verbose = false, offline_mode = false) : Bool

--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,7 @@ version: 2.0
 shards:
   docker_client:
     git: https://github.com/cnf-testsuite/docker_client.git
-    version: 0.1.0+git.commit.32dacefbc3dfcf98c8126ff793c97a3038e9b122
+    version: 1.0.0
 
   popcorn:
     git: https://github.com/icyleaf/popcorn.git

--- a/spec/fixtures/coredns_manifest.yml
+++ b/spec/fixtures/coredns_manifest.yml
@@ -47,16 +47,16 @@ metadata:
     kubernetes.io/name: "CoreDNS"
     app.kubernetes.io/name: coredns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  - services
-  - pods
-  - namespaces
-  verbs:
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+      - pods
+      - namespaces
+    verbs:
+      - list
+      - watch
 ---
 # Source: coredns/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -76,9 +76,9 @@ roleRef:
   kind: ClusterRole
   name: coredns-coredns
 subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: default
+  - kind: ServiceAccount
+    name: default
+    namespace: default
 ---
 # Source: coredns/templates/service.yaml
 apiVersion: v1
@@ -93,16 +93,15 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
     app.kubernetes.io/name: coredns
-  annotations:
-    {}
+  annotations: {}
 spec:
   selector:
     app.kubernetes.io/instance: "coredns"
     k8s-app: "coredns"
     app.kubernetes.io/name: coredns
   ports:
-  - {port: 53, protocol: UDP, name: udp-53}
-  - {port: 53, protocol: TCP, name: tcp-53}
+    - { port: 53, protocol: UDP, name: udp-53 }
+    - { port: 53, protocol: TCP, name: tcp-53 }
   type: ClusterIP
 ---
 # Source: coredns/templates/deployment.yaml
@@ -138,53 +137,53 @@ spec:
         app.kubernetes.io/instance: "coredns"
       annotations:
         checksum/config: 473c46ef33ae3e2811a84fd13c39de8f09ee48ee3de2e6a155431c511d7838f9
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/critical-pod: ""
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       terminationGracePeriodSeconds: 30
       serviceAccountName: default
       dnsPolicy: Default
       containers:
-      - name: "coredns"
-        image: "coredns/coredns:1.7.1"
-        imagePullPolicy: IfNotPresent
-        args: [ "-conf", "/etc/coredns/Corefile" ]
-        volumeMounts:
-        - name: config-volume
-          mountPath: /etc/coredns
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        ports:
-        - {containerPort: 53, protocol: UDP, name: udp-53}
-        - {containerPort: 53, protocol: TCP, name: tcp-53}
-        
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-            scheme: HTTP
-          initialDelaySeconds: 60
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
-        readinessProbe:
-          httpGet:
-            path: /ready
-            port: 8181
-            scheme: HTTP
-          initialDelaySeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 5
+        - name: "coredns"
+          image: "coredns/coredns:1.7.1"
+          imagePullPolicy: IfNotPresent
+          args: ["-conf", "/etc/coredns/Corefile"]
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/coredns
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          ports:
+            - { containerPort: 53, protocol: UDP, name: udp-53 }
+            - { containerPort: 53, protocol: TCP, name: tcp-53 }
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8181
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 5
       volumes:
         - name: config-volume
           configMap:
             name: coredns-coredns
             items:
-            - key: Corefile
-              path: Corefile
+              - key: Corefile
+                path: Corefile

--- a/spec/fixtures/failed_multi_container_pod_manifest.yml
+++ b/spec/fixtures/failed_multi_container_pod_manifest.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-multi-container-pod
+spec:
+  containers:
+    - name: nginx-container
+      image: nginx:latest
+      ports:
+        - containerPort: 80
+    - name: failing-container
+      image: busybox
+      command: ["sh", "-c", "exit 1"]

--- a/spec/fixtures/manifest.yml
+++ b/spec/fixtures/manifest.yml
@@ -12,29 +12,29 @@ data:
 apiVersion: v1
 kind: Pod
 metadata:
-    name: dockerd
-    labels:
-      name: dockerd 
+  name: dockerd
+  labels:
+    name: dockerd-test-label
 spec:
   containers:
-  - name: dockerd
-    image: docker:dind
-    volumeMounts:
-    - name: config-volume
-      mountPath: /etc/docker/daemon.json
-      subPath: config.yaml
-    livenessProbe:
-      tcpSocket:
-        port: 2376
-      initialDelaySeconds: 3
-      periodSeconds: 3
-    readinessProbe:
-      tcpSocket:
-        port: 2376
-      initialDelaySeconds: 3
-      periodSeconds: 3
-    securityContext:
-      privileged: true
+    - name: dockerd
+      image: docker:dind
+      volumeMounts:
+        - name: config-volume
+          mountPath: /etc/docker/daemon.json
+          subPath: config.yaml
+      livenessProbe:
+        tcpSocket:
+          port: 2376
+        initialDelaySeconds: 3
+        periodSeconds: 3
+      readinessProbe:
+        tcpSocket:
+          port: 2376
+        initialDelaySeconds: 3
+        periodSeconds: 3
+      securityContext:
+        privileged: true
   volumes:
     - name: config-volume
       configMap:

--- a/spec/fixtures/multi_container_pod_manifest.yml
+++ b/spec/fixtures/multi_container_pod_manifest.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-container-pod
+spec:
+  containers:
+    - name: container-one
+      image: nginx:latest
+      ports:
+        - containerPort: 80
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+        requests:
+          memory: "32Mi"
+          cpu: "100m"
+    - name: container-two
+      image: redis:latest
+      ports:
+        - containerPort: 6379
+      resources:
+        limits:
+          memory: "64Mi"
+          cpu: "250m"
+        requests:
+          memory: "32Mi"
+          cpu: "100m"

--- a/spec/kubectl_client_spec.cr
+++ b/spec/kubectl_client_spec.cr
@@ -14,7 +14,12 @@ describe "KubectlClient" do
     (KubectlClient.installation_found?(false, true)).should be_true
   end
 
-  it "'#KubectlClient.pods_by_node' should return all pods on a specific node", tags: ["kubectl-nodes"] do
+  it "'#KubectlClient::Get.resource(\"nodes\")' should return the information about a node in json", tags: ["kubectl-nodes"] do
+    json = KubectlClient::Get.resource("nodes")
+    (json["items"].size).should be > 0
+  end
+
+  it "'#KubectlClient::Get.pods_by_nodes' should return all pods on a specific node", tags: ["kubectl-nodes"] do
     pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
     (pods).should_not be_nil
     if pods && pods[0] != Nil
@@ -30,15 +35,14 @@ describe "KubectlClient" do
     end
   end
 
-  it "'#KubectlClient.pods_by_label' should return all pods on a specific node", tags: ["kubectl-nodes"] do
-    # AirGap.bootstrap_cluster()
+  it "'#KubectlClient::Get.pods_by_labels' should return only one pod from manifest.yml", tags: ["kubectl-nodes"] do
     (KubectlClient::Apply.file("./spec/fixtures/manifest.yml")).should be_truthy
     pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
     (pods).should_not be_nil
-    pods = KubectlClient::Get.pods_by_labels(pods, {"name" => JSON.parse("dockerd")})
+    pods = KubectlClient::Get.pods_by_labels(pods, {"name" => "dockerd-test-label"})
     (pods).should_not be_nil
     if pods && pods[0]? != Nil
-      (pods.size).should be > 0
+      (pods.size).should eq 1
       first_node = pods[0]
       if first_node
         (first_node.dig("kind")).should eq "Pod"
@@ -48,29 +52,28 @@ describe "KubectlClient" do
     else
       true.should be_false
     end
+  ensure
+    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
   end
 
-  it "'#KubectlClient.wait_for_resource_key_value' should wait for a resource and key/value combination", tags: ["kubectl-nodes"] do
+  it "'#KubectlClient::Wait.wait_for_resource_key_value' should wait for a resource and key/value combination", tags: ["kubectl-nodes"] do
     (KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")).should be_truthy
-    is_ready = KubectlClient::Wait.wait_for_resource_key_value("Deployment", "coredns-coredns", {"spec", "replicas"}, "1")
-    # is_ready = KubectlClient::Get.wait_for_resource_key_value("Deployment", "coredns-coredns", {"spec", "replicas"})
+    is_ready = KubectlClient::Wait.wait_for_resource_key_value("deployment", "coredns-coredns", {"spec", "replicas"}, "1")
     (is_ready).should be_true
   ensure
-    `kubectl delete -f ./spec/fixtures/coredns_manifest.yml`
+    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
   end
 
-  it "'#KubectlClient.schedulable_nodes_list' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
+  it "'#KubectlClient::Get.schedulable_nodes_list' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
     retry_limit = 50
     retries = 1
     empty_json_any = JSON.parse(%({}))
     nodes = [empty_json_any]
     until (nodes != [empty_json_any]) || retries > retry_limit
-      Log.info { "schedulable_node retry: #{retries}" }
-      sleep 1.0
+      sleep 1.seconds
       nodes = KubectlClient::Get.schedulable_nodes_list
       retries = retries + 1
     end
-    Log.info { "schedulable_node node: #{nodes}" }
     (nodes).should_not be_nil
     if nodes && nodes[0] != Nil
       (nodes.size).should be > 0
@@ -85,29 +88,27 @@ describe "KubectlClient" do
     end
   end
 
-  it "'#KubectlClient.resource_map' should a subset of manifest resource json", tags: ["kubectl-nodes"] do
+  it "'#KubectlClient::Get.resource_map' should extract a subset of manifest resource json", tags: ["kubectl-nodes"] do
     retry_limit = 50
     retries = 1
     empty_json_any = JSON.parse(%({}))
     filtered_nodes = [empty_json_any]
     until (filtered_nodes != [empty_json_any]) || retries > retry_limit
-      Log.info { "resource_map retry: #{retries}" }
-      sleep 1.0
+      sleep 1.seconds
       filtered_nodes = KubectlClient::Get.resource_map(KubectlClient::Get.resource("nodes")) do |item, metadata|
         taints = item.dig?("spec", "taints")
-        Log.debug { "taints: #{taints}" }
         if (taints && taints.dig?("effect") == "NoSchedule")
           nil
         else
-          {:node => item, :name => item.dig?("metadata", "name")}
+          item.dig("metadata", "name").as_s
         end
       end
       retries = retries + 1
     end
-    Log.info { "spec: resource_map node: #{filtered_nodes}" }
     (filtered_nodes).should_not be_nil
     if filtered_nodes
       (filtered_nodes.size).should be > 0
+      (filtered_nodes[0]).should be_a String
     else
       true.should be_false
     end
@@ -129,34 +130,9 @@ describe "KubectlClient" do
     (resp).should be_true
   end
 
-  it "'#KubectlClient.get_nodes' should return the information about a node in json", tags: ["kubectl-nodes"] do
-    json = KubectlClient::Get.resource("nodes")
-    (json["items"].size).should be > 0
-  end
-
   it "'#KubectlClient.container_runtimes' should return all container runtimes", tags: ["kubectl-runtime"] do
     resp = KubectlClient::Get.container_runtimes
     (resp[0].match(KubectlClient::OCI_RUNTIME_REGEX)).should_not be_nil
-  end
-
-  it "'#KubectlClient::Get.schedulable_nodes_list' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
-    retry_limit = 50
-    retries = 1
-    nodes = nil
-    until (nodes && nodes.size > 0 && nodes[0] != KubectlClient::EMPTY_JSON) || retries > retry_limit
-      Log.info { "schedulable_node retry: #{retries}" }
-      sleep 1.0
-      nodes = KubectlClient::Get.schedulable_nodes_list
-      retries = retries + 1
-    end
-    Log.info { "schedulable_node node: #{nodes}" }
-    # resp = KubectlClient::Get.schedulable_nodes
-    (nodes).should_not be_nil
-    if nodes
-      (nodes.size).should be > 0
-      (nodes[0]).should_not be_nil
-      (nodes[0].as_s).should_not be_empty
-    end
   end
 
   it "'#KubectlClient::Get.resource_containers' should return all containers defined in a deployment", tags: ["kubectl-deployment"] do
@@ -164,45 +140,37 @@ describe "KubectlClient" do
     resp = KubectlClient::Get.resource_containers("deployment", "nginx-webapp")
     (resp.size).should be > 0
   ensure
-    # Log.debug  {`./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml deploy_with_chart=false` }
     KubectlClient::Delete.file("./spec/fixtures/sidecar_manifest.yml")
   end
 
-  it "'#KubectlClient.pod_status' should return a status of false if the pod is not installed (failed to install) and other pods exist", tags: ["kubectl-status"] do
-    KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
-    KubectlClient::Apply.file("./spec/fixtures/manifest.yml")
-    KubectlClient::Delete.file("./spec/fixtures/manifest.yml")
+  it "'#KubectlClient::Get.pod_ready?' should return 'true' if the pod has all containers ready", tags: ["kubectl-status"] do
+    KubectlClient::Apply.file("./spec/fixtures/multi_container_pod_manifest.yml")
+    KubectlClient::Wait.resource_wait_for_install("pod", "multi-container-pod")
 
-    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "dockerd")
-    Log.info { resp }
-    resp.should be_false
-  ensure
-    # Log.info {`./cnf-testsuite cnf_cleanup cnf-path=#{cnf}`}
-    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
-  end
-
-  it "'#KubectlClient.pod_status' should return a status of true if the pod is installed and other pods exist", tags: ["kubectl-status"] do
-    cnf = "./sample-cnfs/sample-coredns-cnf"
-    KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
-    KubectlClient::Apply.file("./spec/fixtures/dockerd_manifest.yml")
-    KubectlClient::Wait.resource_wait_for_install("Pod", "dockerd")
-
-    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "dockerd")
-    Log.info { resp }
+    # Also test if pod prefix matching works as intended
+    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "multi-cont")
     resp.should be_true
   ensure
-    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
-    KubectlClient::Delete.file("./spec/fixtures/dockerd_manifest.yml")
+    KubectlClient::Delete.file("./spec/fixtures/multi_container_pod_manifest.yml")
+  end
+
+  it "'#KubectlClient::Get.pod_ready?' should return 'false' if pod has containers that are not ready", tags: ["kubectl-status"] do
+    KubectlClient::Apply.file("./spec/fixtures/failed_multi_container_pod_manifest.yml")
+
+    sleep 3.seconds
+    # Also test if pod prefix matching works as intended
+    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "test")
+    resp.should be_false
+  ensure
+    KubectlClient::Delete.file("./spec/fixtures/failed_multi_container_pod_manifest.yml")
   end
 
   it "'#KubectlClient::Get.pods_by_resource_labels' should return pods for a deployment ", tags: ["kubectl-status"] do
-    cnf = "./sample-cnfs/sample-coredns-cnf"
     KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
-    KubectlClient::Wait.resource_wait_for_install("Pod", "coredns")
+    KubectlClient::Wait.resource_wait_for_install("pod", "coredns")
 
-    resource = KubectlClient::Get.resource("Deployment", "coredns-coredns")
+    resource = KubectlClient::Get.resource("deployment", "coredns-coredns")
     resp = KubectlClient::Get.pods_by_resource_labels(resource)
-    Log.info { resp }
     (resp && !resp.empty?).should be_true
   ensure
     KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")

--- a/spec/kubectl_client_spec.cr
+++ b/spec/kubectl_client_spec.cr
@@ -35,7 +35,7 @@ describe "KubectlClient" do
     (KubectlClient::Apply.file("./spec/fixtures/manifest.yml")).should be_truthy
     pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
     (pods).should_not be_nil
-    pods = KubectlClient::Get.pods_by_label(pods, "name", "dockerd")
+    pods = KubectlClient::Get.pods_by_labels(pods, {"name" => JSON.parse("dockerd")})
     (pods).should_not be_nil
     if pods && pods[0]? != Nil
       (pods.size).should be > 0
@@ -52,7 +52,7 @@ describe "KubectlClient" do
 
   it "'#KubectlClient.wait_for_resource_key_value' should wait for a resource and key/value combination", tags: ["kubectl-nodes"] do
     (KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")).should be_truthy
-    is_ready = KubectlClient::Get.wait_for_resource_key_value("Deployment", "coredns-coredns", {"spec", "replicas"}, "1")
+    is_ready = KubectlClient::Wait.wait_for_resource_key_value("Deployment", "coredns-coredns", {"spec", "replicas"}, "1")
     # is_ready = KubectlClient::Get.wait_for_resource_key_value("Deployment", "coredns-coredns", {"spec", "replicas"})
     (is_ready).should be_true
   ensure
@@ -93,7 +93,7 @@ describe "KubectlClient" do
     until (filtered_nodes != [empty_json_any]) || retries > retry_limit
       Log.info { "resource_map retry: #{retries}" }
       sleep 1.0
-      filtered_nodes = KubectlClient::Get.resource_map(KubectlClient::Get.nodes) do |item, metadata|
+      filtered_nodes = KubectlClient::Get.resource_map(KubectlClient::Get.resource("nodes")) do |item, metadata|
         taints = item.dig?("spec", "taints")
         Log.debug { "taints: #{taints}" }
         if (taints && taints.dig?("effect") == "NoSchedule")
@@ -113,30 +113,25 @@ describe "KubectlClient" do
     end
   end
 
-  it "'Kubectl::Get.wait_for_install' should wait for a cnf to be installed", tags: ["kubectl-install"] do
+  it "'Kubectl::Wait.resource_wait_for_install' should wait for a cnf to be installed", tags: ["kubectl-install"] do
     (KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")).should be_truthy
 
-    KubectlClient::Get.wait_for_install("coredns-coredns")
+    KubectlClient::Wait.resource_wait_for_install("deployment", "coredns-coredns")
     current_replicas = `kubectl get deployments coredns-coredns -o=jsonpath='{.status.readyReplicas}'`
     (current_replicas.to_i > 0).should be_true
   end
 
-  it "'Kubectl::Get.resource_wait_for_uninstall' should wait for a cnf to be installed", tags: ["kubectl-install"] do
+  it "'Kubectl::Wait.resource_wait_for_uninstall' should wait for a cnf to be installed", tags: ["kubectl-install"] do
     (KubectlClient::Apply.file("./spec/fixtures/wordpress_manifest.yml")).should be_truthy
 
     KubectlClient::Delete.file("./spec/fixtures/wordpress_manifest.yml")
-    resp = KubectlClient::Get.resource_wait_for_uninstall("deployment", "wordpress")
+    resp = KubectlClient::Wait.resource_wait_for_uninstall("deployment", "wordpress")
     (resp).should be_true
   end
 
   it "'#KubectlClient.get_nodes' should return the information about a node in json", tags: ["kubectl-nodes"] do
-    json = KubectlClient::Get.nodes
+    json = KubectlClient::Get.resource("nodes")
     (json["items"].size).should be > 0
-  end
-
-  it "'#KubectlClient.container_runtime' should return the information about the container runtime", tags: ["kubectl-runtime"] do
-    resp = KubectlClient::Get.container_runtime
-    (resp.match(KubectlClient::OCI_RUNTIME_REGEX)).should_not be_nil
   end
 
   it "'#KubectlClient.container_runtimes' should return all container runtimes", tags: ["kubectl-runtime"] do
@@ -144,14 +139,14 @@ describe "KubectlClient" do
     (resp[0].match(KubectlClient::OCI_RUNTIME_REGEX)).should_not be_nil
   end
 
-  it "'#KubectlClient.schedulable_nodes' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
+  it "'#KubectlClient::Get.schedulable_nodes_list' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
     retry_limit = 50
     retries = 1
     nodes = nil
-    until (nodes && nodes.size > 0 && !nodes[0].empty?) || retries > retry_limit
+    until (nodes && nodes.size > 0 && nodes[0] != KubectlClient::EMPTY_JSON) || retries > retry_limit
       Log.info { "schedulable_node retry: #{retries}" }
       sleep 1.0
-      nodes = KubectlClient::Get.schedulable_nodes
+      nodes = KubectlClient::Get.schedulable_nodes_list
       retries = retries + 1
     end
     Log.info { "schedulable_node node: #{nodes}" }
@@ -160,41 +155,27 @@ describe "KubectlClient" do
     if nodes
       (nodes.size).should be > 0
       (nodes[0]).should_not be_nil
-      (nodes[0]).should_not be_empty
+      (nodes[0].as_s).should_not be_empty
     end
   end
 
-  it "'#KubectlClient.containers' should return all containers defined in a deployment", tags: ["kubectl-deployment"] do
-    # Log.debug {`./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml wait_count=0`}
+  it "'#KubectlClient::Get.resource_containers' should return all containers defined in a deployment", tags: ["kubectl-deployment"] do
     KubectlClient::Apply.file("./spec/fixtures/sidecar_manifest.yml")
-    resp = KubectlClient::Get.deployment_containers("nginx-webapp")
+    resp = KubectlClient::Get.resource_containers("deployment", "nginx-webapp")
     (resp.size).should be > 0
   ensure
     # Log.debug  {`./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/k8s-sidecar-container-pattern/cnf-testsuite.yml deploy_with_chart=false` }
     KubectlClient::Delete.file("./spec/fixtures/sidecar_manifest.yml")
   end
 
-  it "'#KubectlClient.pod_exists?' should true if a pod exists", tags: ["kubectl-status"] do
-    # Log.debug {`./cnf-testsuite cnf_setup cnf-config=./sample-cnfs/sample-generic-cnf/cnf-testsuite.yml` }
-    KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
-    resp = KubectlClient::Get.pod_exists?("coredns")
-    (resp).should be_true
-  ensure
-    # Log.debug {`./cnf-testsuite cnf_cleanup cnf-config=./sample-cnfs/sample-generic-cnf/cnf-testsuite.yml` }
-    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
-  end
-
   it "'#KubectlClient.pod_status' should return a status of false if the pod is not installed (failed to install) and other pods exist", tags: ["kubectl-status"] do
-    # cnf="./sample-cnfs/sample-coredns-cnf"
-    # Log.info {`./cnf-testsuite cnf_setup cnf-path=#{cnf}`}
-    # Log.info {`./cnf-testsuite uninstall_dockerd`}
     KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
     KubectlClient::Apply.file("./spec/fixtures/manifest.yml")
     KubectlClient::Delete.file("./spec/fixtures/manifest.yml")
 
-    resp = KubectlClient::Get.pod_status(pod_name_prefix: "dockerd").split(",")[2] # true/false
+    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "dockerd")
     Log.info { resp }
-    (resp && !resp.empty? && resp == "true").should be_false
+    resp.should be_false
   ensure
     # Log.info {`./cnf-testsuite cnf_cleanup cnf-path=#{cnf}`}
     KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
@@ -204,23 +185,23 @@ describe "KubectlClient" do
     cnf = "./sample-cnfs/sample-coredns-cnf"
     KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
     KubectlClient::Apply.file("./spec/fixtures/dockerd_manifest.yml")
-    KubectlClient::Get.resource_wait_for_install("Pod", "dockerd")
+    KubectlClient::Wait.resource_wait_for_install("Pod", "dockerd")
 
-    resp = KubectlClient::Get.pod_status(pod_name_prefix: "dockerd").split(",")[2] # true/false
+    resp = KubectlClient::Get.pod_ready?(pod_name_prefix: "dockerd")
     Log.info { resp }
-    (resp && !resp.empty? && resp == "true").should be_true
+    resp.should be_true
   ensure
     KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
     KubectlClient::Delete.file("./spec/fixtures/dockerd_manifest.yml")
   end
 
-  it "'#KubectlClient.pods_by_resource' should return pods for a deployment ", tags: ["kubectl-status"] do
+  it "'#KubectlClient::Get.pods_by_resource_labels' should return pods for a deployment ", tags: ["kubectl-status"] do
     cnf = "./sample-cnfs/sample-coredns-cnf"
     KubectlClient::Apply.file("./spec/fixtures/coredns_manifest.yml")
-    KubectlClient::Get.resource_wait_for_install("Pod", "coredns")
+    KubectlClient::Wait.resource_wait_for_install("Pod", "coredns")
 
     resource = KubectlClient::Get.resource("Deployment", "coredns-coredns")
-    resp = KubectlClient::Get.pods_by_resource(resource)
+    resp = KubectlClient::Get.pods_by_resource_labels(resource)
     Log.info { resp }
     (resp && !resp.empty?).should be_true
   ensure

--- a/spec/kubectl_client_spec.cr
+++ b/spec/kubectl_client_spec.cr
@@ -53,7 +53,7 @@ describe "KubectlClient" do
       true.should be_false
     end
   ensure
-    KubectlClient::Delete.file("./spec/fixtures/coredns_manifest.yml")
+    KubectlClient::Delete.file("./spec/fixtures/manifest.yml")
   end
 
   it "'#KubectlClient::Wait.wait_for_resource_key_value' should wait for a resource and key/value combination", tags: ["kubectl-nodes"] do
@@ -67,7 +67,7 @@ describe "KubectlClient" do
   it "'#KubectlClient::Get.schedulable_nodes_list' should return all schedulable worker nodes", tags: ["kubectl-nodes"] do
     retry_limit = 50
     retries = 1
-    empty_json_any = JSON.parse(%({}))
+    empty_json_any = KubectlClient::EMPTY_JSON
     nodes = [empty_json_any]
     until (nodes != [empty_json_any]) || retries > retry_limit
       sleep 1.seconds
@@ -91,7 +91,7 @@ describe "KubectlClient" do
   it "'#KubectlClient::Get.resource_map' should extract a subset of manifest resource json", tags: ["kubectl-nodes"] do
     retry_limit = 50
     retries = 1
-    empty_json_any = JSON.parse(%({}))
+    empty_json_any = KubectlClient::EMPTY_JSON
     filtered_nodes = [empty_json_any]
     until (filtered_nodes != [empty_json_any]) || retries > retry_limit
       sleep 1.seconds

--- a/spec/kubectl_client_spec.cr
+++ b/spec/kubectl_client_spec.cr
@@ -122,7 +122,7 @@ describe "KubectlClient" do
     (current_replicas.to_i > 0).should be_true
   end
 
-  it "'Kubectl::Wait.resource_wait_for_uninstall' should wait for a cnf to be installed", tags: ["kubectl-install"] do
+  it "'Kubectl::Wait.resource_wait_for_uninstall' should wait for a cnf to be uninstalled", tags: ["kubectl-install"] do
     (KubectlClient::Apply.file("./spec/fixtures/wordpress_manifest.yml")).should be_truthy
 
     KubectlClient::Delete.file("./spec/fixtures/wordpress_manifest.yml")

--- a/src/modules/get.cr
+++ b/src/modules/get.cr
@@ -162,7 +162,7 @@ module KubectlClient
       if nodes == empty_json_any
         logger.notice { "Could not retrieve any nodes with #{full_resource} present" }
       else
-        logger.info { "Nodes with resource #{full_resource} list: #{names_from_json_array_to_s(nodes)}" }
+        logger.info { "Nodes with resource #{full_resource} list: #{KubectlClient.names_from_json_array_to_s(nodes)}" }
       end
 
       nodes
@@ -187,7 +187,7 @@ module KubectlClient
       if nodes == empty_json_any
         logger.notice { "Could not retrieve any node with pod/#{pod_name} present" }
       else
-        logger.info { "Nodes with pod/#{pod_name} list: #{names_from_json_array_to_s(nodes)}" }
+        logger.info { "Nodes with pod/#{pod_name} list: #{KubectlClient.names_from_json_array_to_s(nodes)}" }
       end
 
       nodes
@@ -347,7 +347,7 @@ module KubectlClient
           end
         end
       end
-      logger.info { "Matched #{matched_pods.size} pods: #{names_from_json_array_to_s(matched_pods)}" }
+      logger.info { "Matched #{matched_pods.size} pods: #{KubectlClient.names_from_json_array_to_s(matched_pods)}" }
 
       matched_pods
     end

--- a/src/modules/get.cr
+++ b/src/modules/get.cr
@@ -1,5 +1,7 @@
 module KubectlClient
   module Get
+    @logger : ::Log = Log.for("get")
+
     @@schedulable_nodes_template : String = <<-GOTEMPLATE.strip
     {{- range .items -}}
       {{$taints:=""}}
@@ -15,59 +17,34 @@ module KubectlClient
     {{- end -}}
     GOTEMPLATE
 
-    def self.privileged_containers(namespace = "--all-namespaces")
+    def self.resource(kind : String, resource_name : String?, namespace : String? = nil,
+                      all_namespaces : Bool = false, field_selector : String = "") : JSON::Any
+      logger = @logger.for("resource")
+      logger.info { "Get resource #{kind}" }
+      logger.info { "/#{resource_name.to_s}" } if resource_name
+
+      # resource_name.to_s will expand to "" in case of nil
+      cmd = "kubectl get #{kind} #{resource_name.to_s}"
+      cmd = "#{cmd} --field-selector #{field_selector}" if field_selector
+      cmd = "#{cmd} -n #{namespace}" if namespace && !all_namespaces
+      cmd = "#{cmd} -A" if !namespace && all_namespaces
+      # RLTODO: ensure -o json in all methods is always at the end
+      cmd = "#{cmd} -o json"
+
+      result = ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+
+      parse_get_result(result)
+    end
+
+    def self.privileged_containers(namespace = "--all-namespaces") : JSON::Any
+      logger = @logger.for("privileged_containers")
       cmd = "kubectl get pods #{namespace} -o jsonpath='{.items[*].spec.containers[?(@.securityContext.privileged==true)].name}'"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.privileged_containers")
+      result = ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
 
-      # TODO parse this as json
-      resp = result[:output].split(" ").uniq
-      Log.debug { "kubectl get privileged_containers: #{resp}" }
-      resp
+      parse_get_result(result)
     end
 
-    def self.namespaces(cli = "") : JSON::Any
-      cmd = "kubectl get namespaces -o json #{cli}"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.namespaces")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.nodes : JSON::Any
-      # TODO should this be all namespaces?
-      cmd = "kubectl get nodes -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.nodes")
-      # todo check for success/fail
-      JSON.parse(result[:output])
-    end
-
-    def self.endpoints(all_namespaces = false) : K8sManifest
-      option = all_namespaces ? "--all-namespaces" : ""
-      cmd = "kubectl get endpoints #{option} -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.endpoints")
-      response = result[:output]
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.pods(all_namespaces = true) : K8sManifest
-      option = all_namespaces ? "--all-namespaces" : ""
-      cmd = "kubectl get pods #{option} -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.pods")
-      response = result[:output]
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    # todo put this in a manifest module
-    def self.resource_map(k8s_manifest, &block)
+    private def self.resource_map(k8s_manifest, &block)
       if nodes["items"]?
         items = nodes["items"].as_a.map do |item|
           if nodes["metadata"]?
@@ -77,35 +54,13 @@ module KubectlClient
           end
           yield item, metadata
         end
-        Log.debug { "resource_map items : #{items}" }
         items
       else
         [JSON.parse(%({}))]
       end
     end
 
-    def self.resource_select(&block)
-      Log.info { "resource_select" }
-      if nodes["items"]?
-        Log.info { "nodes size: #{nodes["items"].size}" }
-        Log.info { "nodes : #{nodes}" }
-        items = nodes["items"].as_a.select do |item|
-          if nodes["metadata"]?
-            metadata = nodes["metadata"]
-          else
-            metadata = JSON.parse(%({}))
-          end
-          yield item, metadata
-        end
-        Log.debug { "resource_map items : #{items}" }
-        items
-      else
-        [] of JSON::Any
-      end
-    end
-
-    # todo put this in a manifest module
-    def self.resource_select(k8s_manifest, &block)
+    private def self.resource_select(&block)
       if nodes["items"]?
         items = nodes["items"].as_a.select do |item|
           if nodes["metadata"]?
@@ -115,15 +70,34 @@ module KubectlClient
           end
           yield item, metadata
         end
-        Log.debug { "resource_map items : #{items}" }
         items
       else
         [] of JSON::Any
       end
     end
 
-    def self.schedulable_nodes_list : Array(JSON::Any)
-      retry_limit = 20
+    private def self.resource_select(k8s_manifest, &block)
+      if nodes["items"]?
+        items = nodes["items"].as_a.select do |item|
+          if nodes["metadata"]?
+            metadata = nodes["metadata"]
+          else
+            metadata = JSON.parse(%({}))
+          end
+          yield item, metadata
+        end
+        items
+      else
+        [] of JSON::Any
+      end
+    end
+
+    # TODO: why is this retried at all and even if this is needed, why inside method and not by callers?
+    # why is 'nodes' method failing when its very simple call?
+    def self.schedulable_nodes_list(retry_limit : Int32 = 20) : Array(JSON::Any)
+      logger = @logger.for("schedulable_nodes_list")
+      logger.info { "Retrieving list of schedulable nodes" }
+
       retries = 1
       empty_json_any = [] of JSON::Any
       nodes = empty_json_any
@@ -131,114 +105,125 @@ module KubectlClient
       until (nodes != empty_json_any) || retries > retry_limit
         nodes = KubectlClient::Get.resource_select(KubectlClient::Get.nodes) do |item, metadata|
           taints = item.dig?("spec", "taints")
-          Log.debug { "taints: #{taints}" }
           if (taints && taints.as_a.find { |x| x.dig?("effect") == "NoSchedule" })
-            # EMPTY_JSON
             false
           else
-            # item
             true
           end
         end
         sleep 1
         retries = retries + 1
       end
+
       if nodes == empty_json_any
-        Log.error { "nodes empty: #{nodes}" }
+        logger.warn { "Could not retrieve any schedulable nodes" }
       end
-      Log.debug { "nodes: #{nodes}" }
+      logger.debug { "Schedulable nodes list: #{nodes}" }
+
       nodes
     end
 
-    def self.nodes_by_resource(resource) : Array(JSON::Any)
-      Log.info { "nodes_by_resource resource name: #{resource.dig?("metadata", "name")}" }
-      retry_limit = 50
+    # TODO: why is this retried at all and even if this is needed, why inside method and not by callers?
+    # why is 'nodes' method failing when its very simple call?
+    def self.nodes_by_resource(resource, retry_limit = 20) : Array(JSON::Any)
+      logger = @logger.for("nodes_by_resource")
+      full_resource = "#{resource.dig?("kind")}/#{resource.dig?("metadata", "name")}"
+      logger.info {
+        "Retrieving list of that have resource: #{full_resource}"
+      }
+
       retries = 1
       empty_json_any = [] of JSON::Any
       nodes = empty_json_any
       # Get.nodes seems to have failures sometimes
       until (nodes != empty_json_any) || retries > retry_limit
-        # nodes = KubectlClient::Get.resource_select(KubectlClient::Get.nodes) do |item, metadata|
+        # TODO: matching only by the name might not be enough and this can lead to unexpected behavior
         nodes = KubectlClient::Get.resource_select() do |item, metadata|
           item.dig?("metadata", "name") == resource.dig?("metadata", "name")
         end
         retries = retries + 1
       end
+
       if nodes == empty_json_any
-        Log.error { "nodes empty: #{nodes}" }
+        logger.warn { "Could not retrieve any nodes with #{full_resource}" }
       end
-      Log.debug { "nodes: #{nodes}" }
+      logger.debug { "Nodes with resource #{full_resource} list: #{nodes}" }
+
       nodes
     end
 
-    def self.nodes_by_pod(pod) : Array(JSON::Any)
-      Log.info { "nodes_by_pod pod name: #{pod.dig?("metadata", "name")}" }
-      # retry_limit = 50
-      retry_limit = 3
+    # TODO: why is this retried at all and even if this is needed, why inside method and not by callers?
+    # why is 'nodes' method failing when its very simple call?
+    def self.nodes_by_pod(pod, retry_limit = 3) : Array(JSON::Any)
+      logger = @logger.for("nodes_by_pod")
+      pod_name = "#{pod.dig?("metadata", "name")}"
+      logger.info { "Finding nodes with pod/#{pod_name}" }
+
       retries = 1
       empty_json_any = [] of JSON::Any
       nodes = empty_json_any
       # Get.nodes seems to have failures sometimes
       until (nodes != empty_json_any) || retries > retry_limit
-        # nodes = KubectlClient::Get.resource_select(KubectlClient::Get.nodes) do |item, metadata|
         nodes = KubectlClient::Get.resource_select() do |item, metadata|
           item.dig?("metadata", "name") == pod.dig?("spec", "nodeName")
         end
         retries = retries + 1
       end
+
       if nodes == empty_json_any
-        Log.error { "nodes empty: #{nodes}" }
+        logger.warn { "Could not retrieve any node with pod/#{pod_name}" }
       end
-      Log.debug { "nodes: #{nodes}" }
+      logger.debug { "Nodes with pod/#{pod_name} list: #{nodes}" }
+
       nodes
     end
 
     def self.pods_by_nodes(nodes_json : Array(JSON::Any))
-      Log.debug { "pods_by_node" }
-      nodes_json.map { |item|
-        Log.debug { "items labels: #{item.dig?("metadata", "labels")}" }
+      logger = @logger.for("pods_by_nodes")
+      logger.info { "Creating list of pods found on nodes" }
+
+      pods_a = nodes_json.map { |item|
         node_name = item.dig?("metadata", "labels", "kubernetes.io/hostname")
-        Log.debug { "NodeName: #{node_name}" }
         pods = KubectlClient::Get.pods.as_h["items"].as_a.select do |pod|
           if pod.dig?("spec", "nodeName") == "#{node_name}"
-            Log.debug { "pod: #{pod}" }
             pod_name = pod.dig?("metadata", "name")
-            Log.debug { "PodName: #{pod_name}" }
             true
           else
-            Log.debug { "spec node_name: No Match: #{node_name}" }
             false
           end
         end
       }.flatten
+      logger.debug { "Pods found: #{pods_a}" }
+
+      pods
     end
 
     # todo default flag for schedulable pods vs all pods
-    def self.pods_by_resource(resource_yml : JSON::Any, namespace : String | Nil = nil) : K8sManifestList
-      Log.info { "pods_by_resource" }
-      Log.debug { "pods_by_resource resource: #{resource_yml}" }
-      return [resource_yml] if resource_yml["kind"].as_s.downcase == "pod"
-      Log.info { "resource kind: #{resource_yml["kind"]}" }
+    def self.pods_by_resource_labels(resource_json : JSON::Any, namespace : String? = nil) : Array(JSON::Any)
+      logger = @logger.for("pods_by_resources")
+      kind = resource_json["kind"]?
+      name = resource_json["metadata"]["name"]?
+      logger.info { "Creating list of pods by resource : #{kind}/#{name} labels" }
 
-      # todo change this to kubectl get all pods --all-namespaces -o json for performance
-      pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
-      Log.info { "resource kind: #{resource_yml["kind"]}" }
-      name = resource_yml["metadata"]["name"]?
-      Log.info { "pods_by_resource name: #{name}" }
-      if name
-        # todo deployment labels may not match template metadata labels.
-        # -- may need to match on selector matchlabels instead
-        labels = KubectlClient::Get.resource_spec_labels(resource_yml["kind"].as_s, name.as_s, namespace: namespace).as_h
-        Log.info { "pods_by_resource labels: #{labels}" }
-        KubectlClient::Get.pods_by_labels(pods, labels)
-      else
-        Log.info { "pods_by_resource name is nil" }
-        [] of JSON::Any
+      return [resource_json] if resource_yml["kind"].as_s.downcase == "pod"
+      if !name || !kind
+        logger.warn { "Passed resource is nil" }
+        return [] of JSON::Any
       end
+
+      pods = pods()
+      # todo deployment labels may not match template metadata labels.
+      # -- may need to match on selector matchlabels instead
+      labels = resource_spec_labels(resource_json["kind"].as_s, name.as_s, namespace: namespace).as_h
+      filtered_pods = pods_by_labels(pods, labels)
+
+      filtered_pods
     end
 
     def self.pods_by_labels(pods_json : Array(JSON::Any), labels : Hash(String, JSON::Any))
-      Log.debug { "pods_by_label labels: #{labels}" }
+      logger = @logger.for("pods_by_labels")
+      logger.info { "Creating list of pods that have labels: #{labels}" }
+
       pods_json.select do |pod|
         if labels == Hash(String, JSON::Any).new
           match = false
@@ -251,679 +236,143 @@ module KubectlClient
           if pod.dig?("metadata", "labels", key) == value
             match = true
           else
-            Log.debug { "metadata labels: No Match #{value}" }
             match = false
           end
         end
         match
       end
+      logger.debug { "Matched #{pods_json.size} pods: #{pods_json.map { |item| item.dig?("metadata", "name").as_s }.join(", ")}" }
+
+      pods_json
     end
 
-    def self.pods_by_label(pods_json : Array(JSON::Any), label_key, label_value)
-      Log.debug { "pods_by_label" }
-      pods_json.select do |pod|
-        if pod.dig?("metadata", "labels", label_key) == label_value
-          Log.debug { "pod: #{pod}" }
-          true
-        else
-          Log.debug { "metadata labels: No Match #{label_value}" }
-          false
-        end
-      end
-    end
+    def self.service_by_pod(pod) : JSON::Any?
+      logger = @logger.for("service_by_pod")
+      pod_name = pod.dig("metadata", "name")
+      logger.info { "Matching pod: #{pod_name} to service" }
 
-    def self.deployment(deployment_name : String, namespace : String | Nil = nil) : JSON::Any
-      namespace_opt = ""
-      if namespace != nil
-        namespace_opt = "-n #{namespace}"
-      end
-      cmd = "kubectl get deployment #{deployment_name} -o json #{namespace_opt}"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.deployment")
-      response = result[:output]
-      if result[:status].success? && !response.empty?
-        JSON.parse(response)
-      else
-        JSON.parse(%({}))
-      end
-    end
-
-    def self.resource(kind : String, resource_name : String, namespace : String | Nil = nil) : JSON::Any
-      namespace_opt = ""
-      if namespace != nil
-        namespace_opt = "-n #{namespace.gsub("--namespace ", "").gsub("-n ", "") if namespace}"
-      end
-      cmd = "kubectl get #{kind} #{resource_name} -o json #{namespace_opt}"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.resource")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.save_manifest(deployment_name, output_file) : Bool
-      cmd = "kubectl get deployment #{deployment_name} -o yaml  > #{output_file}"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.safe_manifest")
-      result[:status].success?
-    end
-
-    def self.deployments : JSON::Any
-      cmd = "kubectl get deployments -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.deployments")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(resp)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.services(all_namespaces : Bool = false) : JSON::Any
-      cmd = "kubectl get services -o json"
-      if all_namespaces
-        cmd = "#{cmd} -A"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Get.services")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        resp = JSON.parse(response)
-      else
-        resp = JSON.parse(%({}))
-      end
-      resp
-    end
-
-    def self.service_by_digest(container_digest)
-      Log.info { "service_by_digest container_digest: #{container_digest}" }
-      services = KubectlClient::Get.services
-      matched_service = JSON.parse(%({}))
+      services = KubectlClient::Get.resource("service", all_namespaces: true)
+      matched_service : JSON::Any?
       services["items"].as_a.each do |service|
-        Log.debug { "service_by_digest service: #{service}" }
         service_labels = service.dig?("spec", "selector")
         next unless service_labels
-        # pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
-        pods = KubectlClient::Get.pods
-        service_pods = KubectlClient::Get.pods_by_labels(pods["items"].as_a, service_labels.as_h)
 
-        service_pods.each do |service_pod|
-          Log.debug { "service_by_digest service_pod: #{service_pod}" }
-          statuses = service_pod.dig("status", "containerStatuses")
-          statuses.as_a.each do |status|
-            Log.debug { "service_by_digest status: #{status}" }
-            matched_service = service if status.dig("imageID").as_s.includes?(container_digest)
-          end
-        end
-      end
-      Log.info { "service_by_digest matched_service: #{matched_service}" }
-      matched_service
-    end
-
-    def self.service_by_pod(pod) : (JSON::Any | Nil)
-      Log.info { "service_by_pod pod: #{pod}" }
-      services = KubectlClient::Get.services(all_namespaces: true)
-      matched_service : JSON::Any | Nil = nil
-      services["items"].as_a.each do |service|
-        Log.debug { "service_by_digest service: #{service}" }
-        service_labels = service.dig?("spec", "selector")
-        next unless service_labels
-        pods = KubectlClient::Get.pods
+        pods = KubectlClient::Get.resource("pods", all_namespaces: true)
         service_pods = KubectlClient::Get.pods_by_labels(pods["items"].as_a, service_labels.as_h)
         service_pods.each do |service_pod|
-          Log.debug { "service_by_pod service_pod: #{service_pod}" }
           service_name = service_pod.dig("metadata", "name")
-          Log.info { "service_by_pod service_name: #{service_name}" }
-          pod_name = pod.dig("metadata", "name")
-          Log.info { "service_by_pod pod_name: #{pod_name}" }
           matched_service = service if service_name == pod_name
         end
       end
-      Log.info { "service_by_pod matched_service: #{matched_service}" }
+
+      if matched_service.nil?
+        logger.warn { "Could not match pod to any service" }
+      end
+      logger.debug { "Pod: #{pod_name} matched to service: #{matched_service.dig("metadata", "name").as_s}" }
+
       matched_service
     end
 
-    def self.pods_by_service(service)
-      Log.info { "pods_by_service service: #{service}" }
+    def self.pods_by_service(service) : Array(JSON::Any)?
+      logger = @logger.for("pods_by_service")
+      logger.info { "Matching pods to service: #{service.dig?("metadata", "name")}" }
+
       service_labels = service.dig?("spec", "selector")
       return unless service_labels
+
       pods = KubectlClient::Get.pods
       service_pods = KubectlClient::Get.pods_by_labels(pods["items"].as_a, service_labels.as_h)
     end
 
-    def self.pods_by_digest(container_digest)
-      matched_pod = [] of JSON::Any
-      pods = KubectlClient::Get.pods
+    def self.pods_by_digest(container_digest) : Array(JSON::Any)
+      logger = @logger.for("pods_by_digest")
+      logger.info { "Matching pods to digest: #{container_digest}" }
+
+      matched_pods = [] of JSON::Any
+      pods = KubectlClient::Get.resource("pods", all_namespaces: true)
       pods["items"].as_a.each do |pod|
-        Log.debug { "pod_by_digest pod: #{pod}" }
         statuses = pod.dig?("status", "containerStatuses")
         if statuses
           statuses.as_a.each do |status|
-            Log.debug { "pod_by_digest status: #{status}" }
-            matched_pod << pod if status.dig("imageID").as_s.includes?("#{container_digest}")
+            matched_pods << pod if status.dig("imageID").as_s.includes?("#{container_digest}")
           end
         end
       end
+      logger.debug { "Matched #{matched_pods.size} pods: #{matched_pods.map { |item| item.dig?("metadata", "name").as_s }.join(", ")}" }
+
       matched_pod
     end
 
-    def self.service_url_by_digest(container_digest)
-      Log.info { "service_url_by_digest container_digest: #{container_digest}" }
-      matched_service = service_by_digest(container_digest)
-      service_name = service.dig?("metadata", "name")
-      ports = service.dig?("spec", "ports")
+    def self.resource_containers(kind : String, resource_name : String, namespace : String? = nil) : JSON::Any
+      logger = @logger.for("resource_containers")
+      logger.info { "Get containers of #{kind}/#{resource_name}" }
 
-      url_list = ports.map do |port|
-        "#{service_name}:#{port["port"]}"
-      end
-
-      Log.info { "service_url_by_digest url_list: #{url_list}" }
-      url_list
-    end
-
-    def self.deployment_containers(deployment_name) : JSON::Any
-      resource_containers("deployment", deployment_name)
-    end
-
-    def self.resource_containers(kind, resource_name, namespace : String? = nil) : JSON::Any
-      Log.debug { "kubectl get resource containers kind: #{kind} resource_name: #{resource_name} namespace: #{namespace}" }
       case kind.downcase
       when "pod"
         resp = resource(kind, resource_name, namespace).dig?("spec", "containers")
       when "deployment", "statefulset", "replicaset", "daemonset"
         resp = resource(kind, resource_name, namespace).dig?("spec", "template", "spec", "containers")
-        # unless kind.downcase == "service" ## services have no containers
-      end
-
-      Log.debug { "kubectl get resource containers: #{resp}" }
-      if resp && resp.as_a.size > 0
-        resp
-      else
-        JSON.parse(%([]))
       end
     end
 
-    def self.resource_volumes(kind, resource_name, namespace = "default") : JSON::Any
-      Log.for("KubectlClient::Get.resource_volumes").info { "#{kind} resource_name: #{resource_name} namespace: #{namespace}" }
+    def self.resource_volumes(kind : String, resource_name : String, namespace : String? = nil) : JSON::Any
+      logger = @logger.for("resource_volumes")
+      logger.info { "Get volumes of #{kind}/#{resource_name}" }
 
       case kind.downcase
-      when "service"
-        # Services have no volumes
-        return JSON.parse(%([]))
       when "pod"
         resp = resource(kind, resource_name, namespace).dig?("spec", "volumes")
-      else
+      when "deployment", "statefulset", "replicaset", "daemonset"
         resp = resource(kind, resource_name, namespace).dig?("spec", "template", "spec", "volumes")
       end
-
-      Log.info { "kubectl get resource volumes: #{resp}" }
-      if resp && resp.as_a.size > 0
-        return resp
-      end
-      JSON.parse(%([]))
     end
 
-    def self.secrets(namespace : String | Nil = nil, all_namespaces : Bool = false) : JSON::Any
-      cmd = "kubectl get secrets -o json"
-      if all_namespaces == true
-        cmd = "#{cmd} -A"
-      end
+    private def self.replica_count(kind : String, resource_name : String,
+                                   namespace : String? = nil) : NamedTuple(current: Int32, desired: Int32, unavailable: Int32)
+      logger = @logger.for("replica_count")
+      logger.debug { "Get replica count of #{kind}/#{resource_name}" }
 
-      if namespace != nil
-        cmd = "#{cmd} -n #{namespace}"
-      end
-
-      result = ShellCmd.run(cmd, "KubectlClient::Get.secrets")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.configmaps(namespace : String | Nil = nil, all_namespaces : Bool = false) : JSON::Any
-      cmd = "kubectl get configmaps -o json"
-      if all_namespaces == true
-        cmd = "#{cmd} -A"
-      end
-
-      if namespace != nil
-        cmd = "#{cmd} -n #{namespace}"
-      end
-
-      result = ShellCmd.run(cmd, "KubectlClient::Get.configmaps")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.configmap(name) : JSON::Any
-      cmd = "kubectl get configmap #{name} -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.configmap")
-      response = result[:output]
-
-      if result[:status].success? && !response.empty?
-        return JSON.parse(response)
-      end
-      JSON.parse(%({}))
-    end
-
-    def self.wait_for_install(deployment_name, wait_count : Int32 = 180, namespace : String = "default")
-      resource_wait_for_install("deployment", deployment_name, wait_count, namespace)
-    end
-
-    def self.wait_for_critools(wait_count : Int32 = 10)
-      pods = KubectlClient::Get.pods_by_nodes(KubectlClient::Get.schedulable_nodes_list)
-      pods = KubectlClient::Get.pods_by_label(pods, "name", "cri-tools")
-      ready = false
-      timeout = wait_count
-      `touch /tmp/testfile`
-      pods.map do |pod|
-        until (ready == true || timeout <= 0)
-          sh = KubectlClient.cp("/tmp/testfile #{pod.dig?("metadata", "name")}:/tmp/test")
-          if sh[:status].success?
-            ready = true
-          end
-          sleep 1
-          timeout = timeout - 1
-          Log.info { "Waiting for CRI-Tools Pod" }
-        end
-        if timeout <= 0
-          break
-        end
-      end
-    end
-
-    def self.resource_ready?(kind, namespace, resource_name, kubeconfig = nil) : Bool
-      ready = false
       case kind.downcase
-      when "pod"
-        pod_ready = KubectlClient::Get.pod_status(pod_name_prefix: resource_name, namespace: namespace, kubeconfig: kubeconfig).split(",")[2]
-        Log.info { "pod_ready: #{pod_ready}" }
-        return pod_ready == "true"
       when "replicaset", "deployment", "statefulset"
-        desired = replica_count(kind, namespace, resource_name, "{.status.replicas}", kubeconfig)
-        unavailable = replica_count(kind, namespace, resource_name, "{.status.unavailableReplicas}", kubeconfig)
-        current = replica_count(kind, namespace, resource_name, "{.status.readyReplicas}", kubeconfig)
-        Log.info { "current_replicas: #{current}, desired_replicas: #{desired}, unavailable_replicas: #{unavailable}" }
-
-        ready = current == desired
-
-        if desired == 0 && unavailable >= 1
-          ready = false
-        end
-
-        if (current == -1 || desired == -1)
-          ready = false
-        end
+        current = resource(kind, resource_name, namespace).dig?("status", "readyReplicas")
+        desired = resource(kind, resource_name, namespace).dig?("status", "replicas")
+        unavailable = resource(kind, resource_name, namespace).dig?("status", "unavailableReplicas")
       when "daemonset"
-        desired = replica_count(kind, namespace, resource_name, "{.status.desiredNumberScheduled}", kubeconfig)
-        current = replica_count(kind, namespace, resource_name, "{.status.numberAvailable}", kubeconfig)
-        unavailable = replica_count(kind, namespace, resource_name, "{.status.unavailableReplicas}", kubeconfig)
-        Log.info { "current_replicas: #{current}, desired_replicas: #{desired}" }
-
-        ready = current == desired
-
-        if desired == 0 && unavailable >= 1
-          ready = false
-        end
-
-        if (current == -1 || desired == -1)
-          ready = false
-        end
-      else
-        desired = replica_count(kind, namespace, resource_name, "{.status.replicas}", kubeconfig)
-        current = replica_count(kind, namespace, resource_name, "{.status.readyReplicas}", kubeconfig)
-        unavailable = replica_count(kind, namespace, resource_name, "{.status.unavailableReplicas}", kubeconfig)
-        Log.info { "current_replicas: #{current}, desired_replicas: #{desired}" }
-
-        ready = current == desired
-
-        if desired == 0 && unavailable >= 1
-          ready = false
-        end
-
-        if (current == -1 || desired == -1)
-          ready = false
-        end
+        current = resource(kind, resource_name, namespace).dig?("status", "numberAvailable")
+        desired = resource(kind, resource_name, namespace).dig?("status", "desiredNumberScheduled")
+        unavailable = resource(kind, resource_name, namespace).dig?("status", "unavailableReplicas")
       end
-      ready
+      logger.trace { "replicas: current = #{current}, desired = #{desired}, unavailable = #{unavailable}" }
+
+      {current: current, desired: desired, unavailable: unavailable}
     end
 
-    def self.replica_count(kind, namespace, resource_name, jsonpath, kubeconfig = nil) : Int32
-      cmd = "kubectl get #{kind} --namespace=#{namespace} #{resource_name} -o=jsonpath='#{jsonpath}' #{kubeconfig ? "--kubeconfig " + kubeconfig : ""}"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.replica_count")
-      return -1 if result[:output].empty?
-      result[:output].to_i
-    end
-
-    def self.wait_for_resource_key_value(
-      kind : String,
-      resource_name : String,
-      dig_params : Tuple,
-      value : (String | Nil) = nil,
-      wait_count : Int32 = 180,
-      namespace : String = "default",
-      kubeconfig : String | Nil = nil
-    )
-      is_key_ready = false
-      case kind.downcase
-      when "pod", "replicaset", "deployment", "statefulset", "daemonset"
-        is_ready = resource_wait_for_install(kind, resource_name, wait_count, namespace, kubeconfig)
-      else
-        is_ready = resource_desired_is_available?(kind, resource_name, namespace)
-      end
-      resource = KubectlClient::Get.resource(kind, resource_name, namespace)
-      if is_ready
-        is_key_ready = wait_for_key_value(resource, dig_params, value, wait_count)
-      else
-        is_key_ready = false
-      end
-      is_key_ready
-    end
-
-    def self.wait_for_key_value(resource,
-                                dig_params : Tuple,
-                                value : (String | Nil) = nil,
-                                wait_count : Int32 = 15)
-      Log.info { "wait_for_key_value: params, value: #{dig_params}, #{value}" }
-      second_count = 0
-      key_created = false
-      value_matched = false
-      until (key_created && value_matched) || second_count > wait_count.to_i
-        sleep 3
-        namespace = resource.dig?("metadata", "namespace")
-        if namespace
-          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s)
-        else
-          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s, namespace)
-        end
-
-        Log.info { "resource.dig?(*dig_params): #{value}, #{resource.dig?(*dig_params)}" }
-        if resource.dig?(*dig_params)
-          key_created = true
-          Log.info { "value == {resource.dig(*dig_params)}: #{value}, #{resource.dig(*dig_params)}" }
-          if value == nil
-            value_matched = true
-          elsif value == "#{resource.dig(*dig_params)}"
-            Log.info { "Value matched: true" }
-            value_matched = true
-          end
-        end
-        Log.info { "second count: #{second_count}" }
-        Log.debug { "resource: params: #{resource}, #{dig_params}" }
-        second_count = second_count + 1
-      end
-      key_created && value_matched
-    end
-
-    def self.resource_wait_for_install(
-      kind : String,
-      resource_name : String,
-      wait_count : Int32 = 180,
-      namespace : String = "default",
-      kubeconfig : String | Nil = nil
-    )
-      # Not all cnfs have #{kind}.  some have only a pod.  need to check if the
-      # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod
-      Log.info { "resource_wait_for_install kind: #{kind} resource_name: #{resource_name} namespace: #{namespace} kubeconfig: #{kubeconfig}" }
-      second_count = 0
-
-      # Intialization
-      is_ready = resource_ready?(kind, namespace, resource_name, kubeconfig)
-
-      until is_ready || second_count > wait_count
-        Log.info { "KubectlClient::Get.resource_wait_for_install attempt: #{second_count}; is_ready: #{is_ready}" }
-        sleep 1
-        is_ready = resource_ready?(kind, namespace, resource_name, kubeconfig)
-        second_count = second_count + 1
-      end
-
-      Log.info { "is_ready kind/resource #{kind}, #{resource_name}: #{is_ready}" }
-      return is_ready
-    end
-
-    # TODO add parameter and functionality that checks for individual pods to be successfully terminated
-    def self.resource_wait_for_uninstall(kind : String, resource_name : String, wait_count : Int32 = 180, namespace : String | Nil = "default")
-      # Not all cnfs have #{kind}.  some have only a pod.  need to check if the
-      # passed in pod has a deployment, if so, watch the deployment.  Otherwise watch the pod
-      Log.info { "resource_wait_for_uninstall kind: #{kind} resource_name: #{resource_name} namespace: #{namespace}" }
-      empty_hash = {} of String => JSON::Any
-      second_count = 0
-
-      resource_uninstalled = KubectlClient::Get.resource(kind, resource_name, namespace)
-      Log.debug { "resource_uninstalled #{resource_uninstalled}" }
-      until (resource_uninstalled && resource_uninstalled.as_h == empty_hash) || second_count > wait_count
-        Log.info { "second_count = #{second_count}" }
-        sleep 1
-        resource_uninstalled = KubectlClient::Get.resource(kind, resource_name, namespace)
-        Log.debug { "resource_uninstalled #{resource_uninstalled}" }
-        second_count = second_count + 1
-      end
-
-      if (resource_uninstalled && resource_uninstalled.as_h == empty_hash)
-        Log.info { "kind/resource #{kind}, #{resource_name} uninstalled." }
-        true
-      else
-        Log.info { "kind/resource #{kind}, #{resource_name} is still present." }
-        false
-      end
-    end
-
-    # TODO make dockercluser reference generic
-    def self.wait_for_install_by_apply(manifest_file, wait_count = 180)
-      Log.info { "wait_for_install_by_apply" }
-      second_count = 0
-      apply_result = KubectlClient::Apply.file(manifest_file)
-      apply_resp = apply_result[:output]
-
-      until (apply_resp =~ /cluster.cluster.x-k8s.io\/capi-quickstart unchanged/) != nil && (apply_resp =~ /dockercluster.infrastructure.cluster.x-k8s.io\/capi-quickstart unchanged/) != nil && (apply_resp =~ /kubeadmcontrolplane.controlplane.cluster.x-k8s.io\/capi-quickstart-control-plane unchanged/) != nil && (apply_resp =~ /dockermachinetemplate.infrastructure.cluster.x-k8s.io\/capi-quickstart-control-plane unchanged/) != nil && (apply_resp =~ /dockermachinetemplate.infrastructure.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil && (apply_resp =~ /kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil && (apply_resp =~ /machinedeployment.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil || second_count > wait_count.to_i
-        Log.info { "second_count = #{second_count}" }
-        sleep 1
-        apply_result = KubectlClient::Apply.file(manifest_file)
-        apply_resp = apply_result[:output]
-        second_count = second_count + 1
-      end
-    end
-
-    def self.wait_for_resource_availability(kind : String,
-                                            resource_name,
-                                            namespace = "default",
-                                            wait_count : Int32 = 180)
-      Log.info { "wait_for_resource_availability kind, name: #{kind} #{resource_name}" }
-      second_count = 0
-      resource_created = false
-      until (resource_created) || second_count > wait_count.to_i
-        sleep 3
-        resource_created = resource_desired_is_available?(kind, resource_name, namespace)
-        second_count = second_count + 1
-      end
-      resource_created
-    end
-
-    def self.resource_desired_is_available?(kind : String, resource_name, namespace = "default")
-      cmd = "kubectl get #{kind} #{resource_name} -o=yaml"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      result = ShellCmd.run(cmd, "resource_desired_is_available?")
-      resp = result[:output]
-
-      replicas_applicable = false
-      case kind.downcase
-      when "deployment", "statefulset", "replicaset"
-        # Check if the desired replicas is equal to the ready replicas.
-        # Return true if yes.
-        describe = Totem.from_yaml(resp)
-        Log.info { "desired_is_available describe: #{describe.inspect}" }
-        desired_replicas = describe.get("status").as_h["replicas"].as_i
-        Log.info { "desired_is_available desired_replicas: #{desired_replicas}" }
-        ready_replicas = describe.get("status").as_h["readyReplicas"]?
-        unless ready_replicas.nil?
-          ready_replicas = ready_replicas.as_i
-        else
-          ready_replicas = 0
-        end
-        Log.info { "desired_is_available ready_replicas: #{ready_replicas}" }
-        return desired_replicas == ready_replicas
-      when "pod"
-        # Check if the pod status is ready.
-        # Return true if yes.
-        pod_info = Totem.from_yaml(resp)
-        pod_status_conditions = pod_info["status"]["conditions"]
-        ready_condition = pod_status_conditions.as_a.find do |condition_info|
-          condition_info["type"].as_s? == "Ready" && condition_info["status"].as_s? == "True"
-        end
-
-        if ready_condition
-          return true
-        end
-        return false
-      else
-        # If not any of the above resources,
-        # then assume resource is available.
-        return true
-      end
-    end
-
-    def self.desired_is_available?(deployment_name)
-      resource_desired_is_available?("deployment", deployment_name)
-    end
-
-    # #TODO make a function that gives all the pods for a resource
-    # def self.pods_for_resource(kind : String, resource_name)
-    #   LOGGING.info "kind: #{kind}"
-    #   LOGGING.info "resource_name: #{resource_name}"
-    #   #TODO use get pods and use json
-    #   # all_pods = `kubectl get pods #{field_selector} -o json'`
-    #   all_pods = KubectlClient::Get.pods
-    #   LOGGING.info("all_pods: #{all_pods}")
-    #   # all_pod_names = all_pods[0].split(" ")
-    #   # time_stamps = all_pods[1].split(" ")
-    #   # pods_times = all_pod_names.map_with_index do |name, i|
-    #   #   {:name => name, :time => time_stamps[i]}
-    #   # end
-    #   # LOGGING.info("pods_times: #{pods_times}")
-    #   #
-    #   # latest_pod_time = pods_times.reduce({:name => "not found", :time => "not_found"}) do | acc, i |
-    #   all_pods
-    #
-    # end
-
-    # TODO create a function for waiting for the complete uninstall of a resource
-    # that has pods
-    # TODO get all resources for a cnf
-    # TODO for a replicaset, deployment, statefulset, or daemonset list all pods
-    # TODO check for terminated status of all pods to be complete (check if pod
-    # no longer exists)
-    # def self.resource_wait_for_termination
-    # end
-
-    # TODO remove the need for a split and return name/ true /false in a hash
     # TODO add a spec for this
-    def self.pod_status(pod_name_prefix, field_selector = "", namespace : String | Nil = nil, kubeconfig : String | Nil = nil)
-      Log.info { "pod_status: #{pod_name_prefix} namespace: #{namespace}" }
+    def self.pod_ready?(pod_name_prefix : String, field_selector : String = "", namespace : String? = nil) : Bool
+      logger = @logger.for("pod_status")
+      logger.info { "Get status of pod/#{pod_name_prefix}* with field selector: #{field_selector}" }
 
-      all_pods_cmd = ["kubectl get pods #{field_selector}"]
-      all_pods_cmd << "-o jsonpath='{.items[*].metadata.name},{.items[*].metadata.creationTimestamp}'"
-
-      if kubeconfig
-        all_pods_cmd << "--kubeconfig #{kubeconfig}"
-      end
-
-      if namespace
-        all_pods_cmd << "-n #{namespace}"
-      end
-
-      all_pods_cmd = all_pods_cmd.join(" ")
-      all_pods_result = Process.run(
-        all_pods_cmd,
-        shell: true,
-        output: all_pods_stdout = IO::Memory.new,
-        error: all_pods_stderr = IO::Memory.new
-      )
-      all_pods = all_pods_stdout.to_s.split(",")
-
-      Log.info { all_pods }
-      all_pod_names = all_pods[0].split(" ")
-      time_stamps = all_pods[1].split(" ")
-      pods_times = all_pod_names.map_with_index do |name, i|
-        {:name => name, :time => time_stamps[i]}
-      end
-      Log.info { "pods_times: #{pods_times}" }
-
-      latest_pod_time = pods_times.reduce({:name => "not found", :time => "not_found"}) do |acc, i|
-        # if current i > acc
-        Log.info { "ACC: #{acc}" }
-        Log.info { "I:#{i}" }
-        Log.info { "pod_status: #{pod_name_prefix} namespace: #{namespace}" }
-        if (i[:name] =~ /#{pod_name_prefix}/).nil?
-          Log.info { "pod_name_prefix: #{pod_name_prefix} does not match #{i[:name]}" }
-          acc
+      all_pods_json = resource("pod", pod_name, namespace, field_selector: field_selector)
+      all_pods = all_pods_json.dig?("items").as_a
+        .select do |pod_json|
+          pod_name = pod_json.dig?("metadata", "name").as_s
+          pod_name =~ /pod_name_prefix/ &&
+            pod_json.dig?("status", "containerStatuses").as_a { |cstatus| cstatus.dig?("ready").as_b }
         end
-        if i[:name] =~ /#{pod_name_prefix}/
-          Log.info { "pod_name_prefix: #{pod_name_prefix} namespace: #{namespace} matches #{i[:name]}" }
-          # acc = i
-          if acc[:name] == "not found"
-            Log.info { "acc not found" }
-            # if there is no previous time, use the time in the index
-            previous_time = Time.parse!("#{i[:time]} +00:00", "%Y-%m-%dT%H:%M:%SZ %z")
-          else
-            Log.info { "acc found. time: #{acc[:time]}" }
-            previous_time = Time.parse!("#{acc[:time]} +00:00", "%Y-%m-%dT%H:%M:%SZ %z")
-          end
-          new_time = Time.parse!("#{i[:time]} +00:00", "%Y-%m-%dT%H:%M:%SZ %z")
-          if new_time >= previous_time
-            acc = i
-          else
-            acc
-          end
-        else
-          acc
-        end
-      end
-      Log.info { "latest_pod_time: #{latest_pod_time}" }
+        .map { |pod_json| pod_json.dig?("metadata", "name").as_s }
 
-      if latest_pod_time[:name]
-        pod = latest_pod_time[:name]
-      else
-        pod = ""
-      end
-      # pod = all_pod_names[time_stamps.index(latest_time).not_nil!]
-      # pod = all_pods.select{ | x | x =~ /#{pod_name_prefix}/ }
-      Log.info { "Pods Found: #{pod}" }
-      # TODO refactor to return container statuses
-      status = "#{pod_name_prefix},NotFound,false"
-      if pod != "not found"
-        cmd_opts = "#{kubeconfig ? "--kubeconfig #{kubeconfig}" : ""} #{namespace ? "-n #{namespace}" : ""}"
-        cmd = "kubectl get pods #{pod} -o jsonpath='{.metadata.name},{.status.phase},{.status.containerStatuses[*].ready}' #{cmd_opts}"
-        result = ShellCmd.run(cmd, "pod_status")
-        status = result[:output]
-        Log.debug { "pod_status status before parse: #{status}" }
-        status = status.gsub(" ", ",") # handle mutiple containers
-        Log.debug { "pod_status status after parse: #{status}" }
-      else
-        Log.info { "pod: #{pod_name_prefix} is NOT found" }
-      end
-      Log.info { "pod_status status: #{status}" }
-      status
+      logger.debug { "'Ready' pods: #{all_pods.join(", ")}" }
+      return all_pods.size > 0 ? true : false
     end
 
+    # RLTODO: IM HERE
     def self.node_status(node_name)
       cmd = "kubectl get nodes #{node_name} -o jsonpath='{.status.conditions[?(@.type == \"Ready\")].status}'"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.node_status")
+      result = ShellCMD.run(cmd, "KubectlClient::Get.node_status")
       result[:output]
     end
 
-    def self.deployment_spec_labels(deployment_name) : JSON::Any
-      resource_spec_labels("deployment", deployment_name)
-    end
-
-    def self.resource_spec_labels(kind : String, resource_name : String, namespace : String | Nil = nil) : JSON::Any
+    def self.resource_spec_labels(kind : String, resource_name : String, namespace : String? = nil) : JSON::Any
       Log.debug { "resource_labels kind: #{kind} resource_name: #{resource_name}" }
       case kind.downcase
       when "service"
@@ -959,26 +408,8 @@ module KubectlClient
       # kubectl get nodes --selector='!node-role.kubernetes.io/master' -o 'go-template={{range .items}}{{$taints:=""}}{{range .spec.taints}}{{if eq .effect "NoSchedule"}}{{$taints = print $taints .key ","}}{{end}}{{end}}{{if not $taints}}{{.metadata.name}}{{ "\\n"}}{{end}}{{end}}'
 
       cmd = "kubectl get nodes --selector='!node-role.kubernetes.io/master' -o 'go-template=#{@@schedulable_nodes_template}'"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.worker_nodes")
+      result = ShellCMD.run(cmd, "KubectlClient::Get.worker_nodes")
       result[:output].split("\n")
-    end
-
-    def self.schedulable_nodes : Array(String)
-      # Full command:
-      #
-      # kubectl get nodes -o 'go-template={{range .items}}{{$taints:=""}}{{range .spec.taints}}{{if eq .effect "NoSchedule"}}{{$taints = print $taints .key ","}}{{end}}{{end}}{{if not $taints}}{{.metadata.name}}{{ "\\n"}}{{end}}{{end}}'
-
-      cmd = "kubectl get nodes -o 'go-template=#{@@schedulable_nodes_template}'"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.schedulable_nodes")
-      result[:output].split("\n")
-    end
-
-    def self.pv : JSON::Any
-      # TODO should this be all namespaces?
-      cmd = "kubectl get pv -o json"
-      result = ShellCmd.run(cmd, "KubectlClient::Get.pv")
-      response = result[:output]
-      return JSON.parse(response)
     end
 
     def self.pv_items_by_claim_name(claim_name)
@@ -996,10 +427,6 @@ module KubectlClient
       end.compact
       Log.debug { "pv items : #{items}" }
       items
-    end
-
-    def self.container_runtime
-      nodes["items"][0]["status"]["nodeInfo"]["containerRuntimeVersion"].as_s
     end
 
     def self.container_runtimes

--- a/src/modules/get.cr
+++ b/src/modules/get.cr
@@ -393,9 +393,14 @@ module KubectlClient
 
       all_pods = all_pods_json.dig("items").as_a
         .select do |pod_json|
-          pod_name = pod_json.dig("metadata", "name").as_s.strip
-          all_ready = pod_json.dig("status", "containerStatuses").as_a.all? { |cstatus| cstatus.dig("ready") == true }
-          /#{pod_name_prefix}/.match(pod_name) && all_ready
+          begin
+            pod_name = pod_json.dig("metadata", "name").as_s.strip
+            all_ready = pod_json.dig("status", "containerStatuses").as_a.all? { |cstatus| cstatus.dig("ready") == true }
+            /#{pod_name_prefix}/.match(pod_name) && all_ready
+          rescue ex
+            logger.error { "exception rescued: #{ex}" }
+            false
+          end
         end
         .map { |pod_json| pod_json.dig("metadata", "name").as_s }
 

--- a/src/modules/get.cr
+++ b/src/modules/get.cr
@@ -1,6 +1,6 @@
 module KubectlClient
   module Get
-    @@logger : ::Log = Log.for("get")
+    @@logger : ::Log = Log.for("Get")
 
     @@schedulable_nodes_template : String = <<-GOTEMPLATE.strip
     {{- range .items -}}

--- a/src/modules/get.cr
+++ b/src/modules/get.cr
@@ -375,12 +375,12 @@ module KubectlClient
 
       case kind.downcase
       when "pod"
-        resp = resource(kind, resource_name, namespace).dig("spec", "volumes")
+        resp = resource(kind, resource_name, namespace).dig?("spec", "volumes")
       when "deployment", "statefulset", "replicaset", "daemonset"
-        resp = resource(kind, resource_name, namespace).dig("spec", "template", "spec", "volumes")
+        resp = resource(kind, resource_name, namespace).dig?("spec", "template", "spec", "volumes")
       end
 
-      return EMPTY_JSON if resp.nil?
+      return EMPTY_JSON_ARRAY if resp.nil?
       return resp
     end
 

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -4,6 +4,8 @@ module KubectlClient
 
     def self.status(kind : String, resource_name : String, namespace : String? = nil, timeout : String = "30s")
       logger = @@logger.for("status")
+      logger.info { "Get rollout status of #{kind}/#{resource_name}" }
+
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -12,6 +14,8 @@ module KubectlClient
 
     def self.undo(kind : String, resource_name : String, namespace : String? = nil)
       logger = @@logger.for("undo")
+      logger.info { "Undo rollout of #{kind}/#{resource_name}" }
+
       cmd = "kubectl rollout undo #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -24,7 +28,9 @@ module KubectlClient
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil, values : String? = nil)
       logger = @@logger.for("resource")
-      cmd = "kubectl create #{kind}/#{resource_name}"
+      logger.info { "Apply resource #{kind}/#{resource_name}" }
+
+      cmd = "kubectl apply #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{values}" if values
 
@@ -33,6 +39,8 @@ module KubectlClient
 
     def self.file(file_name : String?, namespace : String? = nil)
       logger = @@logger.for("file")
+      logger.info { "Apply resources from file #{file_name}" }
+
       cmd = "kubectl apply -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -41,6 +49,8 @@ module KubectlClient
 
     def self.namespace(name : String)
       logger = @@logger.for("namespace")
+      logger.info { "Create a namespace: #{name}" }
+
       cmd = "kubectl create namespace #{name}"
 
       ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
@@ -69,8 +79,10 @@ module KubectlClient
       ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
-    def self.file(file_name : String?, namespace : String? = nil, wait : Bool = false)
+    def self.file(file_name : String, namespace : String? = nil, wait : Bool = false)
       logger = @@logger.for("file")
+      logger.info { "Delete resources from file #{file_name}" }
+
       cmd = "kubectl delete -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       if wait
@@ -87,6 +99,8 @@ module KubectlClient
 
     def self.logs(pod_name : String, container_name : String? = nil, namespace : String? = nil, options : String? = nil)
       logger = @@logger.for("logs")
+      logger.debug { "Dump logs of #{pod_name}" }
+
       cmd = "kubectl logs #{pod_name}"
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "#{cmd} -n #{namespace}" if namespace
@@ -99,11 +113,13 @@ module KubectlClient
     # unlike other methods in which method body will build a valid command forced by its arguments.
     def self.exec(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
       logger = @@logger.for("exec")
+      logger.info { "Exec command in pod #{pod_name}" }
+
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "#{cmd} -- #{command}"
-      
+
       result = ShellCMD.run(cmd, logger)
       begin
         ShellCMD.raise_exc_on_error { result }
@@ -119,6 +135,8 @@ module KubectlClient
     # Use with caution as there is no error handling due to process being started in the background.
     def self.exec_bg(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
       logger = @@logger.for("exec_bg")
+      logger.info { "Exec background command in pod #{pod_name}" }
+
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
@@ -130,6 +148,8 @@ module KubectlClient
     def self.copy_to_pod(pod_name : String, source : String, destination : String,
                          container_name : String? = nil, namespace : String? = nil)
       logger = @@logger.for("copy_to_pod")
+      logger.debug { "Copy #{source} to #{pod_name}:#{destination}" }
+
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{source} #{pod_name}:#{destination}"
@@ -141,6 +161,8 @@ module KubectlClient
     def self.copy_from_pod(pod_name : String, source : String, destination : String,
                            container_name : String? = nil, namespace : String? = nil)
       logger = @@logger.for("copy_from_pod")
+      logger.debug { "Copy #{pod_name}:#{source} to #{destination}" }
+
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{pod_name}:#{source} #{destination}"
@@ -151,6 +173,8 @@ module KubectlClient
 
     def self.scale(kind : String, resource_name : String, replicas : Int32, namespace : String? = nil)
       logger = @@logger.for("scale")
+      logger.info { "Scale #{kind}/#{resource_name} to #{replicas} replicas" }
+
       cmd = "kubectl scale #{kind}/#{resource_name} --replicas=#{replicas}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -159,6 +183,8 @@ module KubectlClient
 
     def self.replace_raw(path : String, file_path : String, extra_flags : String? = nil)
       logger = @@logger.for("replace_raw")
+      logger.info { "Replace #{path} with content of #{file_path}" }
+
       cmd = "kubectl replace --raw '#{path}' -f #{file_path}"
       cmd = "#{cmd} #{extra_flags}" if extra_flags
 
@@ -167,6 +193,8 @@ module KubectlClient
 
     def self.annotate(kind : String, resource_name : String, annotatation_str : String, namespace : String? = nil)
       logger = @@logger.for("annotate")
+      logger.info { "Annotate #{kind}/#{resource_name} with #{annotatation_str}" }
+
       cmd = "kubectl annotate #{kind}/#{resource_name} --overwrite #{annotatation_str}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -175,6 +203,8 @@ module KubectlClient
 
     def self.label(kind : String, resource_name : String, labels : Array(String), namespace : String? = nil)
       logger = @@logger.for("label")
+      logger.info { "Label #{kind}/#{resource_name} with #{labels.join(",")}" }
+
       cmd = "kubectl label --overwrite #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -187,6 +217,8 @@ module KubectlClient
 
     def self.cordon(node_name : String)
       logger = @@logger.for("cordon")
+      logger.info { "Cordon node #{node_name}" }
+
       cmd = "kubectl cordon #{node_name}"
 
       ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
@@ -194,6 +226,8 @@ module KubectlClient
 
     def self.uncordon(node_name : String)
       logger = @@logger.for("uncordon")
+      logger.info { "Uncordon node #{node_name}" }
+
       cmd = "kubectl uncordon #{node_name}"
 
       ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
@@ -208,6 +242,7 @@ module KubectlClient
       namespace : String? = nil
     )
       logger = @@logger.for("set_image")
+      logger.info { "Set image of container #{kind}/#{resource_name}/#{container_name} to #{image_name}" }
 
       cmd = version_tag ? 
         "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name}:#{version_tag}" :

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -1,6 +1,6 @@
 module KubectlClient
   module Rollout
-    @@logger : ::Log = Log.for("rollout")
+    @@logger : ::Log = Log.for("Rollout")
 
     def self.status(kind : String, resource_name : String, namespace : String? = nil, timeout : String = "30s")
       logger = @@logger.for("status")
@@ -20,7 +20,7 @@ module KubectlClient
   end
 
   module Apply
-    @@logger : ::Log = Log.for("apply")
+    @@logger : ::Log = Log.for("Apply")
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil, values : String? = nil)
       logger = @@logger.for("resource")
@@ -48,7 +48,7 @@ module KubectlClient
   end
 
   module Delete
-    @@logger : ::Log = Log.for("delete")
+    @@logger : ::Log = Log.for("Delete")
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil,
                       labels : Hash(String, String)? = {} of String => String)
@@ -77,7 +77,7 @@ module KubectlClient
   end
 
   module Utils
-    @@logger : ::Log = Log.for("utils")
+    @@logger : ::Log = Log.for("Utils")
 
     def self.logs(pod_name : String, container_name : String? = nil, namespace : String? = nil, options : String? = nil)
       logger = @@logger.for("logs")

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -95,7 +95,7 @@ module KubectlClient
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
-      cmd = "-- #{command}"
+      cmd = "#{cmd} -- #{command}"
 
       ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
@@ -105,7 +105,7 @@ module KubectlClient
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
-      cmd = "-- #{command}"
+      cmd = "#{cmd} -- #{command}"
 
       ShellCMD.new(cmd, logger)
     end

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -208,6 +208,19 @@ module KubectlClient
       ShellCMD.run(cmd, logger)
     end
 
+    def self.label(kind : String, resource_name : String,
+                   labels : Array(String), namespace : String? = nil) : CMDResult
+      logger = @logger.for("label")
+      cmd = "kubectl label --overwrite #{kind}/#{resource_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      labels.each do |label|
+        cmd = "#{cmd} #{label}"
+      end
+
+      ShellCMD.run(cmd, logger)
+    end
+
     def self.cordon(node_name : String) : CMDResult
       logger = @logger.for("cordon")
       cmd = "kubectl cordon #{node_name}"
@@ -232,9 +245,7 @@ module KubectlClient
     ) : CMDResult
       logger = @logger.for("set_image")
 
-      cmd = version_tag ?
-        "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" :
-        "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
+      cmd = version_tag ? "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" : "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
       ShellCMD.run(cmd, logger)

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -1,58 +1,58 @@
 module KubectlClient
   module Rollout
-    @logger : ::Log = Log.for("rollout")
+    @@logger : ::Log = Log.for("rollout")
 
     def self.status(kind : String, resource_name : String, namespace : String? = nil, timeout : String = "30s")
-      logger = @logger.for("status")
+      logger = @@logger.for("status")
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.undo(kind : String, resource_name : String, namespace : String? = nil)
-      logger = @logger.for("undo")
+      logger = @@logger.for("undo")
       cmd = "kubectl rollout undo #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
   end
 
   module Apply
-    @logger : ::Log = Log.for("apply")
+    @@logger : ::Log = Log.for("apply")
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil, values : String? = nil)
-      logger = @logger.for("resource")
+      logger = @@logger.for("resource")
       cmd = "kubectl create #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{values}" if values
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.file(file_name : String?, namespace : String? = nil)
-      logger = @logger.for("file")
+      logger = @@logger.for("file")
       cmd = "kubectl apply -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.namespace(name : String, kubeconfig : String? = nil)
-      logger = @logger.for("namespace")
+      logger = @@logger.for("namespace")
       cmd = "kubectl create namespace #{name}"
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
   end
 
   module Delete
-    @logger : ::Log = Log.for("delete")
+    @@logger : ::Log = Log.for("delete")
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil,
                       labels : Hash(String, String)? = {} of String => String)
-      logger = @logger.for("resource")
+      logger = @@logger.for("resource")
       cmd = "kubectl delete #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       unless labels.empty?
@@ -60,11 +60,11 @@ module KubectlClient
         cmd = "#{cmd} #{label_options}"
       end
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.file(file_name : String?, namespace : String? = nil, wait : Bool = false)
-      logger = @logger.for("file")
+      logger = @@logger.for("file")
       cmd = "kubectl delete -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       if wait
@@ -72,91 +72,91 @@ module KubectlClient
         logger.info { "Waiting until requested resource is deleted" }
       end
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
   end
 
   module Utils
-    @logger : ::Log = Log.for("utils")
+    @@logger : ::Log = Log.for("utils")
 
     def self.logs(pod_name : String, container_name : String? = nil, namespace : String? = nil, options : String? = nil)
-      logger = @logger.for("logs")
+      logger = @@logger.for("logs")
       cmd = "kubectl logs"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "#{cmd} #{options}" if options
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.exec(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
-      logger = @logger.for("exec")
+      logger = @@logger.for("exec")
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "-- #{command}"
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.exec_bg(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
-      logger = @logger.for("exec_bg")
+      logger = @@logger.for("exec_bg")
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "-- #{command}"
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.new(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.new(cmd, logger) }
     end
 
     def self.copy_to_pod(pod_name : String, source : String, destination : String,
                          container_name : String? = nil, namespace : String? = nil)
-      logger = @logger.for("copy_to_pod")
+      logger = @@logger.for("copy_to_pod")
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{source} #{pod_name}:#{destination}"
       cmd = "#{cmd} -c #{container_name}" if container_name
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.copy_from_pod(pod_name : String, source : String, destination : String,
                            container_name : String? = nil, namespace : String? = nil)
-      logger = @logger.for("copy_from_pod")
+      logger = @@logger.for("copy_from_pod")
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{pod_name}:#{source} #{destination}"
       cmd = "#{cmd} -c #{container_name}" if container_name
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.scale(kind : String, resource_name : String, replicas : Int32, namespace : String? = nil)
-      logger = @logger.for("scale")
+      logger = @@logger.for("scale")
       cmd = "kubectl scale #{kind}/#{resource_name} --replicas=#{replicas}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.replace_raw(path : String, file_path : String, extra_flags : String? = nil)
-      logger = @logger.for("replace_raw")
+      logger = @@logger.for("replace_raw")
       cmd = "kubectl replace --raw '#{path}' -f #{file_path}"
       cmd = "#{cmd} #{extra_flags}" if extra_flags
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.annotate(kind : String, resource_name : String, annotatation_str : String, namespace : String? = nil)
-      logger = @logger.for("annotate")
+      logger = @@logger.for("annotate")
       cmd = "kubectl annotate #{kind}/#{resource_name} --overwrite #{annotatation_str}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.label(kind : String, resource_name : String, labels : Array(String), namespace : String? = nil)
-      logger = @logger.for("label")
+      logger = @@logger.for("label")
       cmd = "kubectl label --overwrite #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
@@ -164,21 +164,21 @@ module KubectlClient
         cmd = "#{cmd} #{label}"
       end
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.cordon(node_name : String)
-      logger = @logger.for("cordon")
+      logger = @@logger.for("cordon")
       cmd = "kubectl cordon #{node_name}"
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.uncordon(node_name : String)
-      logger = @logger.for("uncordon")
+      logger = @@logger.for("uncordon")
       cmd = "kubectl uncordon #{node_name}"
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
 
     def self.set_image(
@@ -189,12 +189,12 @@ module KubectlClient
       version_tag : String? = nil,
       namespace : String? = nil
     )
-      logger = @logger.for("set_image")
+      logger = @@logger.for("set_image")
 
       cmd = version_tag ? "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" : "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
     end
   end
 end

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -242,7 +242,7 @@ module KubectlClient
       namespace : String? = nil
     )
       logger = @@logger.for("set_image")
-      logger.info { "Set image of container #{kind}/#{resource_name}/#{container_name} to #{image_name}" }
+      logger.info { "Set image of container #{resource_kind}/#{resource_name}/#{container_name} to #{image_name}" }
 
       cmd = version_tag ? 
         "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name}:#{version_tag}" :

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -2,50 +2,48 @@ module KubectlClient
   module Rollout
     @logger : ::Log = Log.for("rollout")
 
-    def self.status(kind : String, resource_name : String,
-                    namespace : String? = nil, timeout : String = "30s") : CMDResult
+    def self.status(kind : String, resource_name : String, namespace : String? = nil, timeout : String = "30s")
       logger = @logger.for("status")
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.undo(kind : String, resource_name : String, namespace : String? = nil) : CMDResult
+    def self.undo(kind : String, resource_name : String, namespace : String? = nil)
       logger = @logger.for("undo")
       cmd = "kubectl rollout undo #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
   end
 
   module Apply
     @logger : ::Log = Log.for("apply")
 
-    def self.resource(kind : String, resource_name : String,
-                      namespace : String? = nil, values : String? = nil) : CMDResult
+    def self.resource(kind : String, resource_name : String, namespace : String? = nil, values : String? = nil)
       logger = @logger.for("resource")
       cmd = "kubectl create #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{values}" if values
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.file(file_name : String?, namespace : String? = nil) : CMDResult
+    def self.file(file_name : String?, namespace : String? = nil)
       logger = @logger.for("file")
       cmd = "kubectl apply -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.namespace(name : String, kubeconfig : String? = nil) : CMDResult
+    def self.namespace(name : String, kubeconfig : String? = nil)
       logger = @logger.for("namespace")
       cmd = "kubectl create namespace #{name}"
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
   end
 
@@ -53,7 +51,7 @@ module KubectlClient
     @logger : ::Log = Log.for("delete")
 
     def self.resource(kind : String, resource_name : String, namespace : String? = nil,
-                      labels : Hash(String, String)? = {} of String => String) : CMDResult
+                      labels : Hash(String, String)? = {} of String => String)
       logger = @logger.for("resource")
       cmd = "kubectl delete #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
@@ -62,10 +60,10 @@ module KubectlClient
         cmd = "#{cmd} #{label_options}"
       end
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.file(file_name : String?, namespace : String? = nil, wait : Bool = false) : CMDResult
+    def self.file(file_name : String?, namespace : String? = nil, wait : Bool = false)
       logger = @logger.for("file")
       cmd = "kubectl delete -f #{file_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
@@ -74,7 +72,7 @@ module KubectlClient
         logger.info { "Waiting until requested resource is deleted" }
       end
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
   end
 
@@ -94,7 +92,7 @@ module KubectlClient
     #    to lookup resources belonging to a CNF to wait for uninstall.
     #    We only use this helper in the spec tests, so we use the "kubectl get" output to keep things simple.
     #
-    def self.wait_for_terminations(namespace : String? = nil, wait_count : Int32 = 30)
+    def self.wait_for_terminations(namespace : String? = nil, wait_count : Int32 = 30) : Bool
       logger = @logger.for("wait_for_terminations")
       cmd = "kubectl get all"
       # Check all namespaces by default
@@ -104,112 +102,108 @@ module KubectlClient
       found_terminating = true
       second_count = 0
       while (found_terminating && second_count < wait_count)
-        result = ShellCMD.run(cmd, logger)
+        ShellCMD.raise_exc_on_error &.result = ShellCMD.run(cmd, logger)
         if result[:output].match(/([\s+]Terminating)/)
           found_terminating = true
           second_count = second_count + 1
           sleep(1)
         else
           found_terminating = false
+          return true
         end
 
         if second_count % RESOURCE_WAIT_LOG_INTERVAL == 0
           logger.info { "Waiting until resources are terminated, seconds elapsed: #{second_count}" }
         end
       end
+      return false
     end
 
-    def self.wait_for_condition(kind : String, resource_name : String,
-                                condition : String, namespace : String? = nil) : CMDResult
+    def self.wait_for_condition(kind : String, resource_name : String, condition : String, namespace : String? = nil)
       logger = @logger.for("wait_for_condition")
       cmd = "kubectl wait #{kind}/#{resource_name} --for=#{condition}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.logs(pod_name : String, container_name : String? = nil,
-                  namespace : String? = nil, options : String? = nil) : CMDResult
+    def self.logs(pod_name : String, container_name : String? = nil, namespace : String? = nil, options : String? = nil)
       logger = @logger.for("logs")
       cmd = "kubectl logs"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "#{cmd} #{options}" if options
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.exec(pod_name : String, command : String,
-                  container_name : String? = nil, namespace : String? = nil) : CMDResult
+    def self.exec(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
       logger = @logger.for("exec")
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "-- #{command}"
 
-      ShellCMD.run(full_cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.exec_bg(pod_name : String, command : String,
-                     container_name : String? = nil, namespace : String? = nil) : CMDResult
+    def self.exec_bg(pod_name : String, command : String, container_name : String? = nil, namespace : String? = nil)
       logger = @logger.for("exec_bg")
       cmd = "kubectl exec #{pod_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} -c #{container_name}" if container_name
       cmd = "-- #{command}"
 
-      ShellCMD.new(full_cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.new(cmd, logger)
     end
 
     def self.copy_to_pod(pod_name : String, source : String, destination : String,
-                         container_name : String? = nil, namespace : String? = nil) : CMDResult
+                         container_name : String? = nil, namespace : String? = nil)
       logger = @logger.for("copy_to_pod")
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{source} #{pod_name}:#{destination}"
       cmd = "#{cmd} -c #{container_name}" if container_name
 
-      ShellCMD.run(full_cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
     def self.copy_from_pod(pod_name : String, source : String, destination : String,
-                           container_name : String? = nil, namespace : String? = nil) : CMDResult
+                           container_name : String? = nil, namespace : String? = nil)
       logger = @logger.for("copy_from_pod")
       cmd = "kubectl cp"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} #{pod_name}:#{source} #{destination}"
       cmd = "#{cmd} -c #{container_name}" if container_name
 
-      ShellCMD.run(full_cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.scale(kind : String, resource_name : String, replicas : Int32, namespace : String? = nil) : CMDResult
+    def self.scale(kind : String, resource_name : String, replicas : Int32, namespace : String? = nil)
       logger = @logger.for("scale")
       cmd = "kubectl scale #{kind}/#{resource_name} --replicas=#{replicas}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(full_cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.replace_raw(path : String, file_path : String, extra_flags : String? = nil) : CMDResult
+    def self.replace_raw(path : String, file_path : String, extra_flags : String? = nil)
       logger = @logger.for("replace_raw")
       cmd = "kubectl replace --raw '#{path}' -f #{file_path}"
       cmd = "#{cmd} #{extra_flags}" if extra_flags
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.annotate(kind : String, resource_name : String,
-                      annotatation_str : String, namespace : String? = nil) : CMDResult
+    def self.annotate(kind : String, resource_name : String, annotatation_str : String, namespace : String? = nil)
       logger = @logger.for("annotate")
       cmd = "kubectl annotate #{kind}/#{resource_name} --overwrite #{annotatation_str}"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.label(kind : String, resource_name : String,
-                   labels : Array(String), namespace : String? = nil) : CMDResult
+    def self.label(kind : String, resource_name : String, labels : Array(String), namespace : String? = nil)
       logger = @logger.for("label")
       cmd = "kubectl label --overwrite #{kind}/#{resource_name}"
       cmd = "#{cmd} -n #{namespace}" if namespace
@@ -218,21 +212,21 @@ module KubectlClient
         cmd = "#{cmd} #{label}"
       end
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.cordon(node_name : String) : CMDResult
+    def self.cordon(node_name : String)
       logger = @logger.for("cordon")
       cmd = "kubectl cordon #{node_name}"
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
-    def self.uncordon(node_name : String) : CMDResult
+    def self.uncordon(node_name : String)
       logger = @logger.for("uncordon")
       cmd = "kubectl uncordon #{node_name}"
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
 
     def self.set_image(
@@ -242,13 +236,15 @@ module KubectlClient
       image_name : String,
       version_tag : String? = nil,
       namespace : String? = nil
-    ) : CMDResult
+    )
       logger = @logger.for("set_image")
 
-      cmd = version_tag ? "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" : "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
+      cmd = version_tag ?
+        "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" :
+        "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
       cmd = "#{cmd} -n #{namespace}" if namespace
 
-      ShellCMD.run(cmd, logger)
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
     end
   end
 end

--- a/src/modules/modules.cr
+++ b/src/modules/modules.cr
@@ -1,210 +1,86 @@
 module KubectlClient
-  module Utils
-    def self.wait(cmd)
-      status = Process.run("kubectl wait #{cmd}",
-        shell: true,
-        output: output = IO::Memory.new,
-        error: stderr = IO::Memory.new)
-      Log.info { "KubectlClient.wait output: #{output.to_s}" }
-      Log.info { "KubectlClient.wait stderr: #{stderr.to_s}" }
-      {status: status, output: output, error: stderr}
-    end
-
-    def self.logs(pod_name : String, namespace : String | Nil = nil, options : String | Nil = nil)
-      full_cmd = ["kubectl", "logs"]
-      full_cmd.push("-n #{namespace}") if namespace
-      full_cmd.push(pod_name)
-      full_cmd.push(options) if options
-      full_cmd = full_cmd.join(" ")
-      status = Process.run(full_cmd,
-        shell: true,
-        output: output = IO::Memory.new,
-        error: stderr = IO::Memory.new)
-      Log.debug { "KubectlClient.logs output: #{output.to_s}" }
-      Log.info { "KubectlClient.logs stderr: #{stderr.to_s}" }
-      {status: status, output: output, error: stderr}
-    end
-
-    def self.describe(kind, resource_name, namespace : String | Nil = nil, force_output : Bool = false)
-      # kubectl describe requiretags block-latest-tag
-      cmd = "kubectl describe #{kind} #{resource_name}"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      ShellCmd.run(cmd, "KubectlClient.describe", force_output: force_output)
-    end
-
-    def self.exec(command, namespace : String | Nil = nil, force_output : Bool = false)
-      full_cmd = construct_exec_cmd(command, namespace)
-      ShellCmd.run(full_cmd, "KubectlClient.exec", force_output)
-    end
-
-    def self.exec_bg(command, namespace : String | Nil = nil, force_output : Bool = false)
-      full_cmd = construct_exec_cmd(command, namespace)
-      ShellCmd.new(full_cmd, "KubectlClient.exec_bg", force_output)
-    end
-
-    # Returns a command as a string to be used in exec or exec_bg
-    def self.construct_exec_cmd(command, namespace : String | Nil = nil) : String
-      full_cmd = ["kubectl", "exec"]
-      if namespace
-        full_cmd << "-n #{namespace}"
-      end
-      full_cmd << command
-      full_cmd = full_cmd.join(" ")
-      return full_cmd
-    end
-
-    def self.cp(command)
-      cmd = "kubectl cp #{command}"
-      ShellCmd.run(cmd, "KubectlClient.cp")
-    end
-  end
-
   module Rollout
-    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
-    def self.status(resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
-      Log.info { "Decrecated method. Pass kind in the args KubectlClient::Rollout.status(kind, resource_name, namespace, timeout)" }
-      status(kind: "deployment", resource_name: resource_name, namespace: namespace, timeout: timeout)
-    end
+    @logger : ::Log = Log.for("rollout")
 
-    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
-    def self.undo(resource_name : String, namespace : String | Nil = nil) : Bool
-      Log.info { "Decrecated method. Pass kind in the args KubectlClient::Rollout.undo(kind, resource_name, namespace)" }
-      undo(kind: "deployment", resource_name: resource_name, namespace: namespace)
-    end
-
-    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
-    def self.resource_status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
-      status(kind: kind, resource_name: resource_name, namespace: namespace, timeout: timeout)
-    end
-
-    def self.status(kind : String, resource_name : String, namespace : String | Nil = nil, timeout : String = "30s") : Bool
+    def self.status(kind : String, resource_name : String,
+                    namespace : String? = nil, timeout : String = "30s") : CMDResult
+      logger = @logger.for("status")
       cmd = "kubectl rollout status #{kind}/#{resource_name} --timeout=#{timeout}"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Rollout.status")
-      Log.debug { "rollout status: #{result[:status].success?}" }
-      result[:status].success?
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(cmd, logger)
     end
 
-    def self.undo(kind : String, resource_name : String, namespace : String | Nil = nil) : Bool
+    def self.undo(kind : String, resource_name : String, namespace : String? = nil) : CMDResult
+      logger = @logger.for("undo")
       cmd = "kubectl rollout undo #{kind}/#{resource_name}"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Rollout.undo")
-      Log.debug { "rollback status: #{result[:status].success?}" }
-      result[:status].success?
-    end
-  end
+      cmd = "#{cmd} -n #{namespace}" if namespace
 
-  module Annotate
-    def self.run(cli)
-      cmd = "kubectl annotate #{cli}"
-      ShellCmd.run(cmd, "KubectlClient::Annotate.run")
-    end
-  end
-
-  module Create
-    class AlreadyExistsError < Exception
-    end
-
-    def self.command(cli : String)
-      cmd = "kubectl create #{cli}"
-      result = ShellCmd.run(cmd, "KubectlClient::Create.command")
-      result[:status].success?
-    end
-
-    def self.namespace(name : String, kubeconfig : String | Nil = nil)
-      cmd = "kubectl create namespace #{name}"
-      if kubeconfig
-        cmd = "#{cmd} --kubeconfig #{kubeconfig}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Create.namespace")
-      return true if result[:status].success?
-      raise AlreadyExistsError.new if result[:error].includes?("AlreadyExists")
-      return false
+      ShellCMD.run(cmd, logger)
     end
   end
 
   module Apply
-    def self.file(file_name, kubeconfig : String | Nil = nil, namespace : String | Nil = nil)
-      cmd = ["kubectl apply"]
-      cmd << "--kubeconfig #{kubeconfig}" if kubeconfig
-      cmd << "-n #{namespace}" if namespace
-      cmd << "-f #{file_name}"
-      cmd = cmd.join(" ")
-      ShellCmd.run(cmd, "KubectlClient::Apply.file")
+    @logger : ::Log = Log.for("apply")
+
+    def self.resource(kind : String, resource_name : String,
+                      namespace : String? = nil, values : String? = nil) : CMDResult
+      logger = @logger.for("resource")
+      cmd = "kubectl create #{kind}/#{resource_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} #{values}" if values
+
+      ShellCMD.run(cmd, logger)
     end
 
-    def self.validate(file_name) : Bool
-      # this hits the server btw (so you need a valid K8s cluster)
-      cmd = "kubectl apply --validate=true --dry-run=client -f #{file_name}"
-      result = ShellCmd.run(cmd, "KubectlClient::Apply.validate")
-      result[:status].success?
+    def self.file(file_name : String?, namespace : String? = nil) : CMDResult
+      logger = @logger.for("file")
+      cmd = "kubectl apply -f #{file_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(cmd, logger)
     end
 
-    def self.namespace(name : String, kubeconfig : String | Nil = nil)
-      cmd = "kubectl create namespace #{name} --dry-run=client -o yaml | kubectl apply -f -"
-      if kubeconfig
-        cmd = "kubectl create namespace #{name} --kubeconfig #{kubeconfig} --dry-run=client -o yaml | kubectl apply --kubeconfig #{kubeconfig} -f -"
-        # cmd = "#{cmd} --kubeconfig #{kubeconfig}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Apply.namespace")
-      result[:status].success?
-    end
-  end
+    def self.namespace(name : String, kubeconfig : String? = nil) : CMDResult
+      logger = @logger.for("namespace")
+      cmd = "kubectl create namespace #{name}"
 
-  module Patch
-    def self.spec(kind : String, resource : String, spec_input : String, namespace : String? = nil)
-      namespace_opt = ""
-      if namespace != nil
-        namespace_opt = "-n #{namespace}"
-      end
-      cmd = "kubectl patch #{kind} #{resource} #{namespace_opt} -p '#{spec_input}'"
-      ShellCmd.run(cmd, "KubectlClient::Patch.spec")
-    end
-  end
-
-  module Scale
-    def self.command(cli)
-      cmd = "kubectl scale #{cli}"
-      ShellCmd.run(cmd, "KubectlClient::Scale.command")
+      ShellCMD.run(cmd, logger)
     end
   end
 
   module Delete
-    def self.command(command, labels : Hash(String, String) | Nil = {} of String => String)
-      cmd = "kubectl delete #{command}"
-      if !labels.empty?
+    @logger : ::Log = Log.for("delete")
+
+    def self.resource(kind : String, resource_name : String, namespace : String? = nil,
+                      labels : Hash(String, String)? = {} of String => String) : CMDResult
+      logger = @logger.for("resource")
+      cmd = "kubectl delete #{kind}/#{resource_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      unless labels.empty?
         label_options = labels.map { |key, value| "-l #{key}=#{value}" }.join(" ")
         cmd = "#{cmd} #{label_options}"
       end
-      ShellCmd.run(cmd, "KubectlClient::Delete.command")
+
+      ShellCMD.run(cmd, logger)
     end
 
-    def self.file(file_name, namespace : String | Nil = nil, wait : Bool = false)
+    def self.file(file_name : String?, namespace : String? = nil, wait : Bool = false) : CMDResult
+      logger = @logger.for("file")
       cmd = "kubectl delete -f #{file_name}"
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      if wait == true
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      if wait
         cmd = "#{cmd} --wait=true"
+        logger.info { "Waiting until requested resource is deleted" }
       end
-      ShellCmd.run(cmd, "KubectlClient::Delete.file")
-    end
-  end
 
-  module Replace
-    def self.command(cli : String)
-      cmd = "kubectl replace #{cli}"
-      ShellCmd.run(cmd, "KubectlClient::Replace.command")
+      ShellCMD.run(cmd, logger)
     end
   end
 
   module Utils
+    @logger : ::Log = Log.for("utils")
+
     # Using sleep() to wait for terminating resources is unreliable.
     #
     # 1. Resources still in terminating state can interfere with test runs.
@@ -218,19 +94,17 @@ module KubectlClient
     #    to lookup resources belonging to a CNF to wait for uninstall.
     #    We only use this helper in the spec tests, so we use the "kubectl get" output to keep things simple.
     #
-    def self.wait_for_terminations(namespace : String | Nil = nil, wait_count : Int32 = 30)
+    def self.wait_for_terminations(namespace : String? = nil, wait_count : Int32 = 30)
+      logger = @logger.for("wait_for_terminations")
       cmd = "kubectl get all"
-      if namespace != nil
-        cmd = "#{cmd} -n #{namespace}"
-      else
-        cmd = "#{cmd} -A" # Check all namespaces by default
-      end
+      # Check all namespaces by default
+      cmd = namespace ? "#{cmd} -n #{namespace}" : "#{cmd} -A"
 
       # By default assume there is a resource still terminating.
       found_terminating = true
       second_count = 0
-      while (found_terminating == true && second_count < wait_count)
-        result = ShellCmd.run(cmd, "kubectl_get_resources", force_output: true)
+      while (found_terminating && second_count < wait_count)
+        result = ShellCMD.run(cmd, logger)
         if result[:output].match(/([\s+]Terminating)/)
           found_terminating = true
           second_count = second_count + 1
@@ -238,65 +112,132 @@ module KubectlClient
         else
           found_terminating = false
         end
-        Log.info { "found_terminating = #{found_terminating}; second_count = #{second_count}" }
+
+        if second_count % RESOURCE_WAIT_LOG_INTERVAL == 0
+          logger.info { "Waiting until resources are terminated, seconds elapsed: #{second_count}" }
+        end
       end
     end
-  end
 
-  module Cordon
-    def self.command(command)
-      cmd = "kubectl cordon #{command}"
-      ShellCmd.run(cmd, "KubectlClient::Cordon.command")
+    def self.wait_for_condition(kind : String, resource_name : String,
+                                condition : String, namespace : String? = nil) : CMDResult
+      logger = @logger.for("wait_for_condition")
+      cmd = "kubectl wait #{kind}/#{resource_name} --for=#{condition}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(cmd, logger)
     end
-  end
 
-  module Uncordon
-    def self.command(command)
-      cmd = "kubectl uncordon #{command}"
-      ShellCmd.run(cmd, "KubectlClient::Uncordon.command")
+    def self.logs(pod_name : String, container_name : String? = nil,
+                  namespace : String? = nil, options : String? = nil) : CMDResult
+      logger = @logger.for("logs")
+      cmd = "kubectl logs"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} -c #{container_name}" if container_name
+      cmd = "#{cmd} #{options}" if options
+
+      ShellCMD.run(cmd, logger)
     end
-  end
 
-  module Set
-    def self.image(
+    def self.exec(pod_name : String, command : String,
+                  container_name : String? = nil, namespace : String? = nil) : CMDResult
+      logger = @logger.for("exec")
+      cmd = "kubectl exec #{pod_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} -c #{container_name}" if container_name
+      cmd = "-- #{command}"
+
+      ShellCMD.run(full_cmd, logger)
+    end
+
+    def self.exec_bg(pod_name : String, command : String,
+                     container_name : String? = nil, namespace : String? = nil) : CMDResult
+      logger = @logger.for("exec_bg")
+      cmd = "kubectl exec #{pod_name}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} -c #{container_name}" if container_name
+      cmd = "-- #{command}"
+
+      ShellCMD.new(full_cmd, logger)
+    end
+
+    def self.copy_to_pod(pod_name : String, source : String, destination : String,
+                         container_name : String? = nil, namespace : String? = nil) : CMDResult
+      logger = @logger.for("copy_to_pod")
+      cmd = "kubectl cp"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} #{source} #{pod_name}:#{destination}"
+      cmd = "#{cmd} -c #{container_name}" if container_name
+
+      ShellCMD.run(full_cmd, logger)
+    end
+
+    def self.copy_from_pod(pod_name : String, source : String, destination : String,
+                           container_name : String? = nil, namespace : String? = nil) : CMDResult
+      logger = @logger.for("copy_from_pod")
+      cmd = "kubectl cp"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      cmd = "#{cmd} #{pod_name}:#{source} #{destination}"
+      cmd = "#{cmd} -c #{container_name}" if container_name
+
+      ShellCMD.run(full_cmd, logger)
+    end
+
+    def self.scale(kind : String, resource_name : String, replicas : Int32, namespace : String? = nil) : CMDResult
+      logger = @logger.for("scale")
+      cmd = "kubectl scale #{kind}/#{resource_name} --replicas=#{replicas}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(full_cmd, logger)
+    end
+
+    def self.replace_raw(path : String, file_path : String, extra_flags : String? = nil) : CMDResult
+      logger = @logger.for("replace_raw")
+      cmd = "kubectl replace --raw '#{path}' -f #{file_path}"
+      cmd = "#{cmd} #{extra_flags}" if extra_flags
+
+      ShellCMD.run(cmd, logger)
+    end
+
+    def self.annotate(kind : String, resource_name : String,
+                      annotatation_str : String, namespace : String? = nil) : CMDResult
+      logger = @logger.for("annotate")
+      cmd = "kubectl annotate #{kind}/#{resource_name} --overwrite #{annotatation_str}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(cmd, logger)
+    end
+
+    def self.cordon(node_name : String) : CMDResult
+      logger = @logger.for("cordon")
+      cmd = "kubectl cordon #{node_name}"
+
+      ShellCMD.run(cmd, logger)
+    end
+
+    def self.uncordon(node_name : String) : CMDResult
+      logger = @logger.for("uncordon")
+      cmd = "kubectl uncordon #{node_name}"
+
+      ShellCMD.run(cmd, logger)
+    end
+
+    def self.set_image(
       resource_kind : String,
       resource_name : String,
       container_name : String,
       image_name : String,
-      version_tag : String | Nil = nil,
-      namespace : String | Nil = nil
-    ) : Bool
-      # use --record when setting image to have history
-      # TODO check if image exists in repo? DockerClient::Get.image and image_by_tags
-      cmd = ""
-      if version_tag
-        cmd = "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name}:#{version_tag} --record"
-      else
-        cmd = "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
-      end
-      if namespace
-        cmd = "#{cmd} -n #{namespace}"
-      end
-      result = ShellCmd.run(cmd, "KubectlClient::Set.image")
-      result[:status].success?
-    end
+      version_tag : String? = nil,
+      namespace : String? = nil
+    ) : CMDResult
+      logger = @logger.for("set_image")
 
-    # DEPRECATED: Added only for smooth transition from bug/1726 to main branch
-    def self.image(
-      resource_name : String,
-      container_name : JSON::Any,
-      image_name : String,
-      version_tag : String | Nil = nil,
-      namespace : String | Nil = nil
-    ) : Bool
-      return image(
-        resource_kind: "deployment",
-        resource_name: resource_name,
-        container_name: container_name.as_s,
-        image_name: image_name,
-        version_tag: version_tag,
-        namespace: namespace
-      )
+      cmd = version_tag ?
+        "kubectl set image #{resource_kind}/#{resource_name}#{container_name}=#{image_name}:#{version_tag} --record" :
+        "kubectl set image #{resource_kind}/#{resource_name} #{container_name}=#{image_name} --record"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.run(cmd, logger)
     end
   end
 end

--- a/src/modules/wait.cr
+++ b/src/modules/wait.cr
@@ -1,0 +1,281 @@
+# RLTODO: scope some main log messages as debug anyway
+
+module KubectlClient
+  # Using sleep() to wait for terminating resources is unreliable.
+  #
+  # 1. Resources still in terminating state can interfere with test runs.
+  #    and result in failures of the next test (or spec test).
+  #
+  # 2. Helm uninstall wait option and kubectl delete wait options,
+  #    do not wait for child resources to be fully deleted.
+  #
+  # 3. The output from kubectl json does not clearly indicate when a resource is in a terminating state.
+  #    To wait for uninstall, we can use the app.kubernetes.io/name label,
+  #    to lookup resources belonging to a CNF to wait for uninstall.
+  #    We only use this helper in the spec tests, so we use the "kubectl get" output to keep things simple.
+  #
+  module Wait
+    @logger : ::Log = Log.for("wait")
+
+    def self.wait_for_terminations(namespace : String? = nil, wait_count : Int32 = 30) : Bool
+      logger = @logger.for("wait_for_terminations")
+      cmd = "kubectl get all"
+      # Check all namespaces by default
+      cmd = namespace ? "#{cmd} -n #{namespace}" : "#{cmd} -A"
+
+      # By default assume there is a resource still terminating.
+      found_terminating = true
+      second_count = 0
+      while (found_terminating && second_count < wait_count)
+        ShellCMD.raise_exc_on_error &.result = ShellCMD.run(cmd, logger)
+        if result[:output].match(/([\s+]Terminating)/)
+          found_terminating = true
+          second_count = second_count + 1
+          sleep(1)
+        else
+          found_terminating = false
+          return true
+        end
+
+        if second_count % RESOURCE_WAIT_LOG_INTERVAL == 0
+          logger.info { "Waiting until resources are terminated, seconds elapsed: #{second_count}" }
+        end
+      end
+      return false
+    end
+
+    def self.wait_for_condition(kind : String, resource_name : String, condition : String, namespace : String? = nil)
+      logger = @logger.for("wait_for_condition")
+      cmd = "kubectl wait #{kind}/#{resource_name} --for=#{condition}"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+
+      ShellCMD.raise_exc_on_error &.ShellCMD.run(cmd, logger)
+    end
+
+    private def self.resource_ready?(kind : String, resource_name : String, namespace : String? = nil) : Bool
+      logger = @logger.for("resource_ready?")
+      logger.debug { "Checking if resource #{kind}/#{resource_name} is ready" }
+
+      ready = false
+      case kind.downcase
+      when "pod"
+        return KubectlClient::Get.pod_ready?(resource_name, namespace: namespace)
+      else
+        replicas = KubectlClient::Get.replica_count(kind, resource_name, namespace)
+        ready = replicas[:current] == replicas[:desired]
+        if replicas[:desired] == 0 && replicas[:unavailable] >= 1
+          ready = false
+        end
+        if replicas[:current] == -1 || replicas[:desired] == -1
+          ready = false
+        end
+      end
+
+      ready
+    end
+
+    def self.wait_for_resource_key_value(
+      kind : String,
+      resource_name : String,
+      dig_params : Tuple,
+      value : (String?) = nil,
+      wait_count : Int32 = 180,
+      namespace : String = "default",
+    ) : Bool
+      logger = @logger.for("wait_for_resource_key_value")
+      logger.info { "Waiting for resource #{kind}/#{resource_name} to have #{dig_params.join(".")} = #{value.as_s}" }
+
+      # Check if resource is installed / ready to use
+      case kind.downcase
+      when "pod", "replicaset", "deployment", "statefulset", "daemonset"
+        is_ready = resource_wait_for_install(kind, resource_name, wait_count, namespace)
+      else
+        is_ready = resource_desired_is_available?(kind, resource_name, namespace)
+      end
+
+      # Check if key-value condition is met
+      resource = KubectlClient::Get.resource(kind, resource_name, namespace)
+      is_key_ready = false
+      if is_ready
+        is_key_ready = wait_for_key_value(resource, dig_params, value, wait_count)
+      else
+        is_key_ready = false
+      end
+
+      is_key_ready
+    end
+
+    def self.resource_wait_for_install(
+      kind : String,
+      resource_name : String,
+      wait_count : Int32 = 180,
+      namespace : String = "default",
+    ) : Bool
+      logger = @logger.for("resource_wait_for_install")
+      logger.info { "Waiting for resource #{kind}/#{resource_name} to install" }
+
+      second_count = 0
+      is_ready = resource_ready?(kind, namespace, resource_name)
+      until is_ready || second_count > wait_count
+        if second_count % RESOURCE_WAIT_LOG_INTERVAL == 0
+          logger.info { "seconds elapsed while waiting: #{second_count}" }
+        end
+
+        sleep 1
+        is_ready = resource_ready?(kind, namespace, resource_name)
+        second_count += 1
+      end
+
+      if is_ready
+        logger.info { "#{kind}/#{resource_name} is ready" }
+      else
+        logger.warn { "#{kind}/#{resource_name} is not ready and #{wait_count}s elapsed" }
+      end
+
+      is_ready
+    end
+
+    # TODO add parameter and functionality that checks for individual pods to be successfully terminated
+    def self.resource_wait_for_uninstall(
+      kind : String,
+      resource_name : String,
+      wait_count : Int32 = 180,
+      namespace : String? = "default"
+    ) : Bool
+      logger = @logger.for("resource_wait_for_uninstall")
+      logger.info { "Waiting for resource #{kind}/#{resource_name} to uninstall" }
+
+      second_count = 0
+      resource_uninstalled = KubectlClient::Get.resource(kind, resource_name, namespace)
+      until resource_uninstalled != EMPTY_JSON || second_count > wait_count
+        if second_count % RESOURCE_WAIT_LOG_INTERVAL == 0
+          logger.info { "seconds elapsed while waiting: #{second_count}" }
+        end
+
+        sleep 1
+        resource_uninstalled = KubectlClient::Get.resource(kind, resource_name, namespace)
+        second_count += 1
+      end
+
+      if resource_uninstalled == EMPTY_JSON
+        logger.info { "#{kind}/#{resource_name} was uninstalled" }
+        return true
+      else
+        logger.warn { "#{kind}/#{resource_name} is still present" }
+        return false
+      end
+    end
+
+    # RLTODO: im here
+    def self.wait_for_key_value(resource,
+                                dig_params : Tuple,
+                                value : (String?) = nil,
+                                wait_count : Int32 = 15)
+      Log.info { "wait_for_key_value: params, value: #{dig_params}, #{value}" }
+      second_count = 0
+      key_created = false
+      value_matched = false
+      until (key_created && value_matched) || second_count > wait_count.to_i
+        sleep 3
+        namespace = resource.dig?("metadata", "namespace")
+        if namespace
+          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s)
+        else
+          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s, namespace)
+        end
+
+        Log.info { "resource.dig?(*dig_params): #{value}, #{resource.dig?(*dig_params)}" }
+        if resource.dig?(*dig_params)
+          key_created = true
+          Log.info { "value == {resource.dig(*dig_params)}: #{value}, #{resource.dig(*dig_params)}" }
+          if value == nil
+            value_matched = true
+          elsif value == "#{resource.dig(*dig_params)}"
+            Log.info { "Value matched: true" }
+            value_matched = true
+          end
+        end
+        Log.info { "second count: #{second_count}" }
+        Log.debug { "resource: params: #{resource}, #{dig_params}" }
+        second_count = second_count + 1
+      end
+      key_created && value_matched
+    end
+
+    # TODO make dockercluser reference generic
+    def self.wait_for_install_by_apply(manifest_file, wait_count = 180)
+      Log.info { "wait_for_install_by_apply" }
+      second_count = 0
+      apply_result = KubectlClient::Apply.file(manifest_file)
+      apply_resp = apply_result[:output]
+
+      until (apply_resp =~ /cluster.cluster.x-k8s.io\/capi-quickstart unchanged/) != nil && (apply_resp =~ /dockercluster.infrastructure.cluster.x-k8s.io\/capi-quickstart unchanged/) != nil && (apply_resp =~ /kubeadmcontrolplane.controlplane.cluster.x-k8s.io\/capi-quickstart-control-plane unchanged/) != nil && (apply_resp =~ /dockermachinetemplate.infrastructure.cluster.x-k8s.io\/capi-quickstart-control-plane unchanged/) != nil && (apply_resp =~ /dockermachinetemplate.infrastructure.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil && (apply_resp =~ /kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil && (apply_resp =~ /machinedeployment.cluster.x-k8s.io\/capi-quickstart-md-0 unchanged/) != nil || second_count > wait_count.to_i
+        Log.info { "second_count = #{second_count}" }
+        sleep 1
+        apply_result = KubectlClient::Apply.file(manifest_file)
+        apply_resp = apply_result[:output]
+        second_count = second_count + 1
+      end
+    end
+
+    def self.wait_for_resource_availability(kind : String,
+                                            resource_name,
+                                            namespace = "default",
+                                            wait_count : Int32 = 180)
+      Log.info { "wait_for_resource_availability kind, name: #{kind} #{resource_name}" }
+      second_count = 0
+      resource_created = false
+      until (resource_created) || second_count > wait_count.to_i
+        sleep 3
+        resource_created = resource_desired_is_available?(kind, resource_name, namespace)
+        second_count = second_count + 1
+      end
+      resource_created
+    end
+
+    def self.resource_desired_is_available?(kind : String, resource_name, namespace = "default")
+      cmd = "kubectl get #{kind} #{resource_name} -o=yaml"
+      if namespace
+        cmd = "#{cmd} -n #{namespace}"
+      end
+      result = ShellCMD.run(cmd, "resource_desired_is_available?")
+      resp = result[:output]
+
+      replicas_applicable = false
+      case kind.downcase
+      when "deployment", "statefulset", "replicaset"
+        # Check if the desired replicas is equal to the ready replicas.
+        # Return true if yes.
+        describe = Totem.from_yaml(resp)
+        Log.info { "desired_is_available describe: #{describe.inspect}" }
+        desired_replicas = describe.get("status").as_h["replicas"].as_i
+        Log.info { "desired_is_available desired_replicas: #{desired_replicas}" }
+        ready_replicas = describe.get("status").as_h["readyReplicas"]?
+        unless ready_replicas.nil?
+          ready_replicas = ready_replicas.as_i
+        else
+          ready_replicas = 0
+        end
+        Log.info { "desired_is_available ready_replicas: #{ready_replicas}" }
+        return desired_replicas == ready_replicas
+      when "pod"
+        # Check if the pod status is ready.
+        # Return true if yes.
+        pod_info = Totem.from_yaml(resp)
+        pod_status_conditions = pod_info["status"]["conditions"]
+        ready_condition = pod_status_conditions.as_a.find do |condition_info|
+          condition_info["type"].as_s? == "Ready" && condition_info["status"].as_s? == "True"
+        end
+
+        if ready_condition
+          return true
+        end
+        return false
+      else
+        # If not any of the above resources,
+        # then assume resource is available.
+        return true
+      end
+    end
+  end
+end

--- a/src/modules/wait.cr
+++ b/src/modules/wait.cr
@@ -78,7 +78,7 @@ module KubectlClient
       kind : String,
       resource_name : String,
       dig_params : Tuple,
-      value : (String?) = nil,
+      value : String? = nil,
       wait_count : Int32 = 180,
       namespace : String = "default",
     ) : Bool
@@ -90,7 +90,8 @@ module KubectlClient
       when "pod", "replicaset", "deployment", "statefulset", "daemonset"
         is_ready = resource_wait_for_install(kind, resource_name, wait_count, namespace)
       else
-        is_ready = resource_ready?(kind, resource_name, namespace)
+        # If not any of the above resources, then assume resource is available.
+        is_ready = true
       end
 
       # Check if key-value condition is met
@@ -194,7 +195,8 @@ module KubectlClient
         if namespace
           resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s)
         else
-          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s, namespace)
+          resource = KubectlClient::Get.resource(resource["kind"].as_s, resource.dig("metadata", "name").as_s,
+            namespace: namespace)
         end
 
         if resource.dig?(*dig_params)

--- a/src/modules/wait.cr
+++ b/src/modules/wait.cr
@@ -17,6 +17,8 @@ module KubectlClient
 
     def self.wait_for_terminations(namespace : String? = nil, wait_count : Int32 = 30) : Bool
       logger = @@logger.for("wait_for_terminations")
+      logger.debug { "Wait for terminations in ns #{namespace}" }
+
       cmd = "kubectl get all"
       # Check all namespaces by default
       cmd = namespace ? "#{cmd} -n #{namespace}" : "#{cmd} -A"
@@ -46,6 +48,8 @@ module KubectlClient
       kind : String, resource_name : String, condition : String, wait_count : Int32 = 180, namespace : String? = nil
     )
       logger = @@logger.for("wait_for_condition")
+      logger.info { "Wait for condition #{condition} in #{kind}/#{resource_name}" }
+
       cmd = "kubectl wait #{kind}/#{resource_name} --for=#{condition} --timeout=#{wait_count}s"
       cmd = "#{cmd} -n #{namespace}" if namespace
 

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -5,8 +5,10 @@ module KubectlClient
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|podman|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
   EMPTY_JSON        = JSON.parse(%({}))
+  EMPTY_JSON_ARRAY        = JSON.parse(%([]))
 
   # kubectl CMD errors
   ALREADY_EXISTS_ERR_MATCH = "AlreadyExists"
-  NOT_FOUND_ERR_MATCH      = "NotFound"
+  NOT_FOUND_ERR_MATCH      = "NotFound|does not exist"
+  NETWORK_ERR_MATCH = "Unable to connect to the server"
 end

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -10,5 +10,5 @@ module KubectlClient
   # kubectl CMD errors
   ALREADY_EXISTS_ERR_MATCH = "AlreadyExists"
   NOT_FOUND_ERR_MATCH      = "NotFound|does not exist"
-  NETWORK_ERR_MATCH = "Unable to connect to the server"
+  NETWORK_ERR_MATCH = "Unable to connect to the server|connection refused"
 end

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -4,4 +4,5 @@ module KubectlClient
   RESOURCE_WAIT_LOG_INTERVAL = 10
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|podman|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
+  EMPTY_JSON        = JSON.parse(%({}))
 end

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -7,6 +7,6 @@ module KubectlClient
   EMPTY_JSON        = JSON.parse(%({}))
 
   # kubectl CMD errors
-  ALREADY_EXISTS_ERR_MATCH = "Error from server (AlreadyExists):"
-  NOT_FOUND_ERR_MATCH      = "Error from server (NotFound):"
+  ALREADY_EXISTS_ERR_MATCH = "AlreadyExists"
+  NOT_FOUND_ERR_MATCH      = "NotFound"
 end

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -5,4 +5,8 @@ module KubectlClient
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|podman|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
   EMPTY_JSON        = JSON.parse(%({}))
+
+  # kubectl CMD errors
+  ALREADY_EXISTS_ERR_MATCH = "Error from server (AlreadyExists):"
+  NOT_FOUND_ERR_MATCH      = "Error from server (NotFound):"
 end

--- a/src/utils/constants.cr
+++ b/src/utils/constants.cr
@@ -1,6 +1,7 @@
 module KubectlClient
-  DEFAULT_LOCAL_BINARY_PATH = "tools/git/linux-amd64/docker"
-  BASE_CONFIG               = "./config.yml"
+  DEFAULT_LOCAL_BINARY_PATH  = "tools/git/linux-amd64/docker"
+  BASE_CONFIG                = "./config.yml"
+  RESOURCE_WAIT_LOG_INTERVAL = 10
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|podman|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i
 end

--- a/src/utils/system_information.cr
+++ b/src/utils/system_information.cr
@@ -3,6 +3,7 @@ require "colorize"
 require "totem"
 require "./utils.cr"
 
+# TODO (rafal-lal): move stdout_ from here to main cnti
 def kubectl_installation(verbose = false, offline_mode = false)
   gmsg = "No Global kubectl version found"
   lmsg = "No Local kubectl version found"


### PR DESCRIPTION
Generally ready to review, but not yet ready to merge as changes made here needs to be reflected in main cnti-testsuite.

Changes:
- add logging scopes with `Log.for()`
- clean many unneeded log messages (used during development?)
- refactor existing logs to be more informative, `log.info` should be clear message in english, `log.debug` should hold informations useful to debugging and not produce wall of logs with values of variables or other development leftovers. Also add `log.trace` usage for very verbose logs like outputs of commands etc.
- add throwing of exceptions in case of errors in CMD execution - one of the main problems with this shard in my opinion - lack of error handling, there was simply no way to tell if some of the methods failed or not. In case of the simpler ones `Process::Status`, `stdout` and `stderr` were returned in format of NamedTuple - so that was ok (some of the methods returned NamedTuple, some just Bool - this was standarised as well). It is not idomatic to crystal-lang `Exceptions` based approach but acceptable. In case of more complex methods, CLI command that fetches some resource from the kubernetes could fail, and method would ignore this fact and continue with the logic and return some value - in most cases empty one. This leaves the caller of the method in complete unknown - did the method fail?, did it finish succesfully and returned empty value?, is the empty value valid response or not?. Error handling is actaully very important in testsuite - lets look at scenario in which test case that checks if number of replicas can be changed is executed. Lets say some 3rd or 4th call to KubectlClient shard fails due to random connectivity error to the cluster. Testcase fails. Is the user notified that testcase failed due to network error and should be restarted or it fails without proper feedback leaving users with 0 points for it? Exceptions should be caught somewhere at testcase level and clearly described to users. In situation where exception is somewhat expected, it can be `rescued` and some adequate to sitation action can be taken. Reference [Crystal's way to do error handling is by raising and rescuing exceptions](https://crystal-lang.org/reference/1.15/syntax_and_semantics/exception_handling.html).
- remove many non-generic `Get` submodule methods with universal `Get::resource` one - there were couple of methods
repeating the very same pattern: `kubectl get <kind> <resource_name>`, but the kind was hardcoded to deployment, service, pods, nodes... The only changing value was `kind`. This is making this shard harder to maintain, debug and keep in consistent state, I've seen many duplicated functionality across this shard mostly due to lack of universality in methods.
- remove some of the most exotic methods e.g. `container_digests_by_nodes` and others - the reason was mainly that these methods were not used at all in main cnti-testsuite. The second reason was that these methods are just too specific to make sense. We can take golang kubectl-client package as reference. It mostly provides functions to fetch or post the resources, any aggregations or filtering is mainly specific to certain use cases and is done inside solutions code, not inside library. Some reasonable helpers are definitely okay, but here we have situation when we have those quite specific helpers, and they are just not used anywhere. Instead main cnti-testsuite uses this shard to fetch the resources (as it should be) and leaves tons of these helpers here, forgotten, unmainted, unused, filled with TODOs and develop time logs.
- remove commented out code
- add new file with `Wait` submodule with methods extracted from wider `Get` submodule - there were enough of them that creation of new submodule made sense
- add new constants
- simplify logic of some methods where possible
- add arguments and return types to many of the methods
- update test cases

This is not everything but enough as first step. Second would be to move this shard to main cnti-testsuite as maintaining those shards outside of main codebase is problematic in itself.
